### PR TITLE
Bug fix in mapping recursive property denominators to JavaBean graphs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,13 @@
 		<dependency>
 			<groupId>org.databene</groupId>
 			<artifactId>databene-formats</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.databene</groupId>
+			<artifactId>databene-commons</artifactId>
+			<version>1.0.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updated reference to databene-formats-1.0.1, added reference to databene-commons 1.0.1 in order to disambiguate it from the indirect dependencies via databene-formats and edifatto.
