### PR TITLE
Add CommandLineService default implementation

### DIFF
--- a/src/main/resources/aludraservice.properties.default
+++ b/src/main/resources/aludraservice.properties.default
@@ -10,3 +10,4 @@ org.aludratest.service.separatedfile.SeparatedFileService=org.aludratest.service
 org.aludratest.config.AludraTestConfig=org.aludratest.config.impl.AludraTestConfigImpl
 org.aludratest.util.retry.AutoRetry=org.aludratest.util.retry.AutoRetryImpl
 org.aludratest.data.DataConfiguration=org.aludratest.data.DataConfigurationImpl
+org.aludratest.service.cmdline.CommandLineService=org.aludratest.service.cmdline.impl.CommandLineServiceImpl


### PR DESCRIPTION
The aludraservice.properties.default specifies the default implementations for all services when no other implementation is specified via configuration mechanisms. The CommandLineService must be added here, otherwise no CommandLineService could be retrieved by clients (or every client would have to specify this implementation explicitly).