### PR TITLE
Fixed ElementLocators, StaleExceptionReference and focus issue

### DIFF
--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
@@ -145,6 +145,20 @@ public class LocatorSupport {
         }
     }
 
+    /** Provides the parent of a given {@link WebElement}.
+     * @param child
+     * @return */
+    public WebElement getParent(final WebElement child) {
+        WebElement parent = child.findElement(By.xpath(".."));
+        return wrapElement(parent, new ElementLookup() {
+            @Override
+            public WebElement perform() {
+                return child.findElement(By.xpath(".."));
+            }
+        });
+
+    }
+
     /** Implements Selenium 2's {@link By} interface in a way that supports AludraTest's {@link GUIElementLocator}s
      * @param locator the AludraTest locator of the element(s) to look up.
      * @return */
@@ -224,26 +238,34 @@ public class LocatorSupport {
      *            the element lookup is repeated
      * @return the element if it is found
      * @throws NoSuchElementException if no matching element is found */
-    private WebElement findElement(GUIElementLocator locator, long relocationTimeout) {
-        return wrapElement(locator, driver.findElement(by(locator)), relocationTimeout);
+    private WebElement findElement(final GUIElementLocator locator, final long relocationTimeout) {
+        WebElement element = driver.findElement(by(locator));
+        return wrapElement(element, new ElementLookup() {
+            @Override
+            public WebElement perform() {
+                return waitUntilPresent(locator, relocationTimeout);
+            }
+        });
     }
 
-    private WebElement wrapElement(GUIElementLocator locator, WebElement element, long timeOutInMillis) {
+    private WebElement wrapElement(WebElement element, ElementLookup lookup) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        InvocationHandler handler = new WebElementProxyHandler(locator, element, timeOutInMillis);
+        InvocationHandler handler = new WebElementProxyHandler(element, lookup);
         return (WebElement) Proxy.newProxyInstance(classLoader, new Class[] { ElementWrapper.class }, handler);
+    }
+
+    interface ElementLookup {
+        WebElement perform();
     }
 
     class WebElementProxyHandler implements InvocationHandler {
 
-        private GUIElementLocator locator;
         private WebElement realElement;
-        private long timeOutInMillis;
+        private ElementLookup lookup;
 
-        public WebElementProxyHandler(GUIElementLocator locator, WebElement realElement, long timeOutInMillis) {
-            this.locator = locator;
+        public WebElementProxyHandler(WebElement realElement, ElementLookup lookup) {
             this.realElement = realElement;
-            this.timeOutInMillis = timeOutInMillis;
+            this.lookup = lookup;
         }
 
         @Override
@@ -256,7 +278,7 @@ public class LocatorSupport {
             }
         }
 
-        private Object invokeRealElement(Method method, Object[] args) throws IllegalAccessException, InvocationTargetException {
+        private Object invokeRealElement(Method method, Object[] args) throws Throwable {
             StaleElementReferenceException staleEx = null;
             // try to get z order up to 3 times
             for (int invocationCount = 0; invocationCount < MAX_RETRIES_ON_STALE_ELEMENT; invocationCount++) {
@@ -266,11 +288,15 @@ public class LocatorSupport {
                 catch (InvocationTargetException invocationEx) {
                     Throwable cause = AludraTestUtil.unwrapInvocationTargetException(invocationEx);
                     if (cause instanceof StaleElementReferenceException) {
-                        // ... on failure, catch and store the exception...
+                        // ... on stale refs, catch and store the exception...
                         staleEx = (StaleElementReferenceException) cause;
                         // relocate the element
-                        this.realElement = waitUntilPresent(locator, timeOutInMillis);
+                        this.realElement = lookup.perform();
                         // and repeat (or finish) the loop
+                    }
+                    else {
+                        // in case of another failure, provide it to the caller immediately
+                        throw cause;
                     }
                 }
             }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
@@ -56,7 +56,6 @@ public class LocatorSupport {
 
     private static final int SECOND_MILLIS = 1000;
     private static final int DEFAULT_IMPLICIT_WAIT_MILLIS = 100;
-    private static final int ISSUE_402_HANGING_TIMEOUT = 3000;
 
     private final WebDriver driver;
     private final SeleniumWrapperConfiguration config;
@@ -90,7 +89,7 @@ public class LocatorSupport {
                 return findElementImmediately(locator);
             }
         };
-        Callable<WebElement> finderWithTimeout = TimeoutService.createCallableWithTimeout(finder, ISSUE_402_HANGING_TIMEOUT);
+        Callable<WebElement> finderWithTimeout = TimeoutService.createCallableWithTimeout(finder, config.getTimeout());
         try {
             return RetryService.call(finderWithTimeout, java.util.concurrent.TimeoutException.class, 1);
         }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Verification.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Verification.java
@@ -60,8 +60,8 @@ public class Selenium2Verification extends AbstractSelenium2Action implements We
         try {
             wrapper.waitUntilClickable(locator, getTimeout());
         }
-        catch (Exception e) { // NOSONAR
-            throw new FunctionalFailure("Element not editable");
+        catch (AutomationException e) { // NOSONAR
+            throw new FunctionalFailure(e.getMessage());
         }
     }
 
@@ -74,7 +74,7 @@ public class Selenium2Verification extends AbstractSelenium2Action implements We
         catch (FunctionalFailure e) {
             throw e;
         }
-        catch (Exception e) { // NOSONAR
+        catch (AutomationException e) { // NOSONAR
             // this is the desired outcome
         }
     }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
@@ -43,7 +43,6 @@ import org.aludratest.service.gui.web.selenium.selenium2.condition.AnyDropDownOp
 import org.aludratest.service.gui.web.selenium.selenium2.condition.DropDownBoxOptionLabelsPresence;
 import org.aludratest.service.gui.web.selenium.selenium2.condition.DropDownOptionLocatable;
 import org.aludratest.service.gui.web.selenium.selenium2.condition.ElementAbsence;
-import org.aludratest.service.gui.web.selenium.selenium2.condition.ElementClickable;
 import org.aludratest.service.gui.web.selenium.selenium2.condition.ElementCondition;
 import org.aludratest.service.gui.web.selenium.selenium2.condition.ElementValuePresence;
 import org.aludratest.service.gui.web.selenium.selenium2.condition.OptionSelected;
@@ -78,7 +77,6 @@ import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -633,10 +631,7 @@ public class Selenium2Wrapper {
     }
 
     public void focus(GUIElementLocator locator) {
-        WebElement element = findElementImmediately(locator);
-        if (!ElementClickable.isClickable(element)) {
-            throw new AutomationException("Element not editable");
-        }
+        WebElement element = waitUntilClickable(locator, configuration.getTimeout());
         executeScript("arguments[0].focus()", element);
     }
 
@@ -712,12 +707,12 @@ public class Selenium2Wrapper {
     }
 
     @SuppressWarnings("unchecked")
-    public void waitUntilClickable(GUIElementLocator locator, long timeOutInMillis) {
+    public WebElement waitUntilClickable(GUIElementLocator locator, long timeOutInMillis) {
+        ElementCondition condition = new ElementCondition(locator, locatorSupport, true, true);
         try {
-            waitFor(ExpectedConditions.elementToBeClickable(LocatorSupport.by(locator)), timeOutInMillis,
-                    NoSuchElementException.class);
+            return waitFor(condition, timeOutInMillis, NoSuchElementException.class);
         } catch (TimeoutException e) {
-            throw new AutomationException("Element not editable"); // NOSONAR
+            throw new AutomationException(condition.getMessage()); // NOSONAR
         }
     }
 

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/ZIndexSupport.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/ZIndexSupport.java
@@ -41,6 +41,8 @@ public class ZIndexSupport {
     private final LocatorSupport locatorSupport;
     private final WebDriver driver;
 
+    // constructor -------------------------------------------------------------
+
     /** Constructor.
      * @param locatorSupport */
     public ZIndexSupport(LocatorSupport locatorSupport) {
@@ -48,10 +50,14 @@ public class ZIndexSupport {
         this.driver = locatorSupport.getDriver();
     }
 
+    // properties --------------------------------------------------------------
+
     /** @return the {@link #locatorSupport} */
     public LocatorSupport getLocatorSupport() {
         return locatorSupport;
     }
+
+    // operational interface ---------------------------------------------------
 
     /** Checks if a element is blocked by a modal dialog.
      * @param element the element to be checked
@@ -76,7 +82,7 @@ public class ZIndexSupport {
         try {
             do {
                 zIndex = element.getCssValue("z-index");
-                element = element.findElement(By.xpath(".."));
+                element = locatorSupport.getParent(element);
             } while ("auto".equals(zIndex) && element != null);
         } catch (InvalidSelectorException e) {
             // this occurs when having reached the root element


### PR DESCRIPTION
Resolving an ElementLocators can be too time consuming for a fix timeout of 3sec, so use the global timeout value.