### PR TITLE
Fix error in git-reset integration test.

### DIFF
--- a/src/test/java/org/aludratest/service/gitclient/GitClientIntegrationTest.java
+++ b/src/test/java/org/aludratest/service/gitclient/GitClientIntegrationTest.java
@@ -411,6 +411,9 @@ public class GitClientIntegrationTest extends AbstractAludraServiceTest {
     }
 
     private void createTestFilesForReset(GitClient gitClient) throws IOException {
+        // give git-reset a target commit
+        InvocationData data = new InvocationData("git", "commit", "--allow-empty", "-m", "Initial commit.");
+        gitClient.invokeGenerically(data);
         // create the files
         createFile(UNTRACKED_FILE, "untracked", false, gitClient);
         createFile(ADDED_FILE, "added", true, gitClient);


### PR DESCRIPTION
The setup helper needs to commit at least once, because git-init creates an empty repository.  Without a commit, we get a "Failed to resolve 'HEAD' as a valid ref" error.