### PR TITLE
Introduce GUI Component Factory infrastructure

### DIFF
--- a/src/main/java/org/aludratest/codecheck/rule/pmd/guicomponent/OnlyUIMapsConstructGUIComponent.java
+++ b/src/main/java/org/aludratest/codecheck/rule/pmd/guicomponent/OnlyUIMapsConstructGUIComponent.java
@@ -15,11 +15,11 @@
  */
 package org.aludratest.codecheck.rule.pmd.guicomponent;
 
-import org.aludratest.codecheck.rule.pmd.AbstractAludraTestRule;
-import org.aludratest.service.gui.component.GUIComponent;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 
-import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import org.aludratest.codecheck.rule.pmd.AbstractAludraTestRule;
 
 /**
  * See <code>src/main/resources/pmd-rules-aludra.xml</code> or the project Site
@@ -31,15 +31,21 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 public class OnlyUIMapsConstructGUIComponent extends AbstractAludraTestRule {
 
     @Override
-    public Object visit(ASTAllocationExpression node, Object data) {
+    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (isUIMapClass(node) || isUIMapHelperClass(node) || isUIMapUtilityClass(node)) {
-            return super.visit(node, data);
+            return null;
         }
 
-        // check if somebody else tries to allocate a GUIComponent
-        Class<?> allocClass = node.getFirstChildOfType(ASTClassOrInterfaceType.class).getType();
-        if (allocClass != null && GUIComponent.class.isAssignableFrom(allocClass)) {
-            addViolationWithMessage(data, node, "Only UIMap related classes are allowed to create GUIComponent objects");
+        return super.visit(node, data);
+    }
+
+    @Override
+    public Object visit(ASTName node, Object data) {
+        if (node.jjtGetParent() instanceof ASTPrimaryPrefix) {
+            String image = node.getImage();
+            if (image != null && image.endsWith(".getComponentFactory")) {
+                addViolationWithMessage(data, node, "Only UIMap related classes are allowed to access a GUI Component Factory");
+            }
         }
 
         return super.visit(node, data);

--- a/src/main/java/org/aludratest/service/gui/AludraGUI.java
+++ b/src/main/java/org/aludratest/service/gui/AludraGUI.java
@@ -16,6 +16,7 @@
 package org.aludratest.service.gui;
 
 import org.aludratest.service.AludraService;
+import org.aludratest.service.gui.component.GUIComponentFactory;
 
 /**
  * Specialization of the {@link AludraService} interface
@@ -35,5 +36,10 @@ public interface AludraGUI extends AludraService {
     /** @see AludraService#check() */
     @Override
     public GUICondition check();
+
+    /** Returns a factory which can be used to create GUI components for this service.
+     * 
+     * @return A factory which can be used to create GUI components for this service, never <code>null</code>. */
+    public GUIComponentFactory getComponentFactory();
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Button.java
+++ b/src/main/java/org/aludratest/service/gui/component/Button.java
@@ -15,79 +15,13 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
-import org.databene.commons.Validator;
+import org.aludratest.service.gui.component.impl.ValueComponent;
 
 /**
  * Represents a button in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann
  */
-public class Button extends InputComponent<Button> implements ValueComponent {
-
-    private ValueComponentHelper helper = new ValueComponentHelper(this, true);
-
-    /**
-     * Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced button
-     */
-    public Button(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     *  @param aludraGui the underlying {@link AludraGUI} service instance
-     *  @param locator a locator for the referenced element
-     *  @param elementName an explicit name to use for the component */
-    public Button(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
-
-    @Override
-    public String getText() {
-        return helper.getText();
-    }
-
-    @Override
-    public void assertTextEquals(String expectedText) {
-        helper.assertTextEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextNotEquals(String expectedText) {
-        helper.assertTextNotEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextContains(String expectedText) {
-        helper.assertTextContains(expectedText);
-    }
-
-    @Override
-    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextMatches(Validator<String> validator) {
-        helper.assertTextMatches(validator);
-    }
-
-    @Override
-    public void assertValueGreaterThan(String value) {
-        helper.assertValueGreaterThan(value);
-    }
-
-    @Override
-    public void assertValueLessThan(String value) {
-        helper.assertValueLessThan(value);
-    }
+public interface Button extends InputComponent<Button>, ValueComponent {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Checkbox.java
+++ b/src/main/java/org/aludratest/service/gui/component/Checkbox.java
@@ -15,75 +15,34 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
-import org.aludratest.util.data.helper.DataMarkerCheck;
 
 /** Represents a checkbox in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann */
-public class Checkbox extends InputComponent<Checkbox> {
-
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced checkbox */
-    public Checkbox(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced element
-     * @param elementName an explicit name to use for the component */
-    public Checkbox(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
+public interface Checkbox extends InputComponent<Checkbox> {
 
     /** Selects or deselects a Checkbox due to overgiven String If the text is null or marked as null the operation is not
      * executed.
      * @param selectString */
-    public void select(String selectString) {
-        if (!DataMarkerCheck.isNull(selectString)) {
-            Boolean select = Boolean.parseBoolean(selectString);
-            if (select) {
-                select();
-            }
-            else {
-                deselect();
-            }
-        }
-    }
+    public void select(String selectString);
 
     /** Selects the checkbox. */
-    public void select() {
-        perform().selectCheckbox(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void select();
 
     /** Unselects the checkbox. */
-    public void deselect() {
-        perform().deselectCheckbox(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void deselect();
 
     /** Asserts that the checkbox is checked. */
-    public void assertChecked() {
-        verify().assertChecked(elementType, elementName, getLocator());
-    }
+    public void assertChecked();
 
     /** Asserts that the checkbox is in the in the state expected by the passed text If the text is null or marked as null the
      * operation is not executed.
      * @param text <code>"true"</code> or <code>"false"</code>. Anything else (non-null) will be interpreted as <code>false</code> */
-    public void assertChecked(String text) {
-        if (!DataMarkerCheck.isNull(text)) {
-            Boolean expected = Boolean.parseBoolean(text);
-            verify().assertChecked(elementType, elementName, expected, getLocator());
-        }
-    }
+    public void assertChecked(String text);
 
     /** Returns if the checkbox is currently checked or not.
      * 
      * @return <code>true</code> if the checkbox is currently checked (has a checkmark in its box), <code>false</code> otherwise. */
-    public boolean isChecked() {
-        return check().isElementChecked(elementType, elementName, getLocator());
-    }
+    public boolean isChecked();
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Element.java
+++ b/src/main/java/org/aludratest/service/gui/component/Element.java
@@ -17,148 +17,84 @@ package org.aludratest.service.gui.component;
 
 import org.aludratest.service.gui.AludraGUI;
 import org.aludratest.service.locator.element.GUIElementLocator;
-import org.aludratest.util.data.helper.DataMarkerCheck;
 
-/** Parent class for GUI Elements e.g. Button.
+/** Parent interface for GUI Elements e.g. Button.
  * 
  * TODO document waitingUntilTaskCompletion feature
  * 
  * @author Joerg Langnickel
  * @author Volker Bergmann
  * @param <E> Type of the concrete element, to be used by subclasses. */
-public abstract class Element<E extends Element<E>> extends GUIComponent {
-
-    protected int taskCompletionTimeout;
-
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a {@link GUIElementLocator} for the referenced element */
-    protected Element(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-        this.taskCompletionTimeout = -1;
-    }
-
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a {@link GUIElementLocator} for the referenced element
-     * @param elementName an explicit name to use for the element */
-    protected Element(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-        this.taskCompletionTimeout = -1;
-    }
+public interface Element<E extends Element<E>> extends GUIComponent {
 
     /** @return the element's locator */
-    public GUIElementLocator getLocator() {
-        return (GUIElementLocator) locator;
-    }
+    public GUIElementLocator getLocator();
 
     /** Activates the <i>waiting until task completion</i> feature on the underlying aludraGUI with the default value for the task
      * completion timeout.
-     * @return */
-    public E waitingUntilTaskCompletion() {
-        return waitingUntilTaskCompletion(0);
-    }
+     * @return This object. */
+    public E waitingUntilTaskCompletion();
 
     /** Sets the {@link #taskCompletionTimeout} to the specified value.
      * @param waitTime the wait time to apply. A negative number disables the wait feature, 0 implicitly activates the
      *            {@link AludraGUI}'s default, a positive value is used as explicit timeout.
-     * @return */
-    @SuppressWarnings("unchecked")
-    public E waitingUntilTaskCompletion(int waitTime) {
-        this.taskCompletionTimeout = waitTime;
-        return (E) this;
-    }
+     * @return This object. */
+    public E waitingUntilTaskCompletion(int waitTime);
 
     /** Asserts that the element is editable. */
-    public void assertEditable() {
-        verify().assertEditable(elementType, elementName, getLocator());
-    }
+    public void assertEditable();
 
     /** Asserts that the element is not editable. */
-    public void assertNotEditable() {
-        verify().assertNotEditable(elementType, elementName, getLocator());
-    }
+    public void assertNotEditable();
 
     /** Asserts that the element is present */
-    public void assertPresent() {
-        verify().assertElementPresent(elementType, elementName, getLocator());
-    }
+    public void assertPresent();
 
     /** Asserts that the element is not present */
-    public void assertNotPresent() {
-        verify().assertElementNotPresent(elementType, elementName, getLocator());
-    }
+    public void assertNotPresent();
 
     /** Asserts that the element is visible */
-    public void assertVisible() {
-        verify().assertVisible(elementType, elementName, getLocator());
-    }
+    public void assertVisible();
 
     /** Asserts that the element has the focus. */
-    public void assertFocus() {
-        verify().assertHasFocus(elementType, elementName, getLocator());
-    }
+    public void assertFocus();
 
     /** Sets the focus on this element */
-    public void focus() {
-        perform().focus(elementType, elementName, getLocator());
-    }
+    public void focus();
 
     /** Double clicks the element. */
-    public void doubleClick() {
-        perform().doubleClick(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void doubleClick();
 
     /** Single-clicks the element. */
-    public void click() {
-        perform().click(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void click();
 
     /**
      * Selectable click- clicks only when provided string is not null, not marked as null and provided string is "true"
      * @param click -String
      */
-    public void click(String click) {
-        if (!DataMarkerCheck.isNull(click)) {
-            if (Boolean.parseBoolean(click)) {
-                click();
-            }
-        }
-    }
+    public void click(String click);
 
     /**
      * Selectable not editable click - clicks only when provided string is not null, not marked as null and provided string is "true"
      * @param click -String
      */
-    public void clickNotEditable(String click) {
-        if (!DataMarkerCheck.isNull(click)) {
-            if (Boolean.parseBoolean(click)) {
-                clickNotEditable();
-            }
-        }
-    }
+    public void clickNotEditable(String click);
 
     /**
      * Click on an element which is not editable (accept the non-editable state)
      */
-    public void clickNotEditable() {
-        perform().clickNotEditable(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void clickNotEditable();
 
     /**
      * Double click on an element which is not editable (accept the non-editable state)
      */
-    public void doubleClickNotEditable() {
-        perform().doubleClickNotEditable(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
+    public void doubleClickNotEditable();
 
     /** Checks if the specified element is somewhere on the page within the standard timeout.
      * 
      * @return <code>true</code> if the element was found present somewhere on the page within the standard timeout,
      *         <code>false</code> otherwise. */
-    public boolean isPresent() {
-        return check().isElementPresent(elementType, elementName, getLocator());
-    }
+    public boolean isPresent();
 
     /**
      * Checks if the specified element is somewhere on the page and in foreground
@@ -166,26 +102,20 @@ public abstract class Element<E extends Element<E>> extends GUIComponent {
      * 
      * @return <code>true</code> if the element was found present somewhere on the page and in foreground within the standard timeout,
      *         <code>false</code> otherwise. */
-    public boolean isPresentAndInForeground() {
-        return check().isElementPresentandInForeground(elementType, elementName, getLocator());
-    }
+    public boolean isPresentAndInForeground();
 
     /** Checks if the specified element is somewhere on the page within a given timeout
      * 
      * @param timeout max time to wait for the element to become present.
      * @return <code>true</code> if the element was found present somewhere on the page within the given timeout,
      *         <code>false</code> otherwise. */
-    public boolean isPresent(long timeout) {
-        return check().isElementPresent(elementType, elementName, getLocator(), timeout);
-    }
+    public boolean isPresent(long timeout);
 
     /** Checks if the specified element is nowhere on the page within the standard timeout.
      * 
      * @return <code>true</code> if the element was <b>not</b> found present somewhere on the page within the standard timeout,
      *         <code>false</code> otherwise. */
-    public boolean isNotPresent() {
-        return check().isElementNotPresent(elementType, elementName, getLocator());
-    }
+    public boolean isNotPresent();
 
     /** Checks if the specified element is nowhere on the page within the standard timeout.
      * 
@@ -193,23 +123,17 @@ public abstract class Element<E extends Element<E>> extends GUIComponent {
      * 
      * @return <code>true</code> if the element was <b>not</b> found present somewhere on the page within the given timeout,
      *         <code>false</code> otherwise. */
-    public boolean isNotPresent(long timeout) {
-        return check().isElementNotPresent(elementType, elementName, getLocator(), timeout);
-    }
+    public boolean isNotPresent(long timeout);
 
     /** Checks if the specified element is visible within the standard timeout.
      * 
      * @return <code>true</code> if the element is visible, <code>false</code> otherwise. */
-    public boolean isVisible() {
-        return check().isElementVisible(elementType, elementName, getLocator());
-    }
+    public boolean isVisible();
 
     /** Checks if the specified element is visible within the given timeout.
      * 
      * @param timeout Max time to wait for the element to become visible.
      * 
      * @return <code>true</code> if the element was found visible during the given timeout, <code>false</code> otherwise. */
-    public boolean isVisible(long timeout) {
-        return check().isElementVisible(elementType, elementName, getLocator(), timeout);
-    }
+    public boolean isVisible(long timeout);
 }

--- a/src/main/java/org/aludratest/service/gui/component/GUIComponent.java
+++ b/src/main/java/org/aludratest/service/gui/component/GUIComponent.java
@@ -15,97 +15,12 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.gui.GUICondition;
-import org.aludratest.service.gui.GUIInteraction;
-import org.aludratest.service.gui.GUIVerification;
-import org.aludratest.service.locator.Locator;
 
-/**
- * Parent class for all Components of a Graphical User Interface.
+/** Parent interface for all Components of a Graphical User Interface, e.g. Elements or Windows.
+ * 
  * @author Marcel Malitz
  * @author Volker Bergmann
  */
-public abstract class GUIComponent {
-
-    protected AludraGUI aludraGui;
-    protected Locator locator;
-    protected String elementType;
-    protected String elementName;
-
-
-    // constructors ------------------------------------------------------------
-
-    /** Constructor using the default component naming scheme.
-     *  @param aludraGui the {@link AludraGUI} instance this GUI component is connected to
-     *  @param locator the {@link Locator} by which the {@link AludraGUI} can query the component */
-    protected GUIComponent(AludraGUI aludraGui, Locator locator) {
-        this(aludraGui, locator, null);
-    }
-
-    /**
-     * Constructor applying a custom component name.
-     * 
-     * @param aludraGui
-     *            the {@link AludraGUI} instance this GUI component is connected
-     *            to
-     * @param locator
-     *            the {@link Locator} by which the {@link AludraGUI} can query
-     *            the component
-     * @param elementName
-     *            a custom name for the element
-     * 
-     * @throws IllegalArgumentException
-     *             if aludraGui or locator is <code>null</code>.
-     * 
-     * */
-    protected GUIComponent(AludraGUI aludraGui, Locator locator, String elementName) {
-        // make null check here to avoid later, hard to trace NPEs
-        if (aludraGui == null) {
-            throw new IllegalArgumentException("aludraGui is null");
-        }
-        if (locator == null) {
-            throw new IllegalArgumentException("locator is null");
-        }
-        this.aludraGui = aludraGui;
-        this.locator = locator;
-        this.elementType = getClass().getSimpleName();
-        this.elementName = (elementName != null ? elementName : defaultElementName());
-    }
-
-
-    // utility methods for child classes ---------------------------------------
-
-    protected GUIInteraction perform() {
-        return aludraGui.perform();
-    }
-
-    protected GUIVerification verify() {
-        return aludraGui.verify();
-    }
-
-    protected GUICondition check() {
-        return aludraGui.check();
-    }
-
-
-    // private helpers ---------------------------------------------------------
-
-    private String defaultElementName() {
-        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-        int i = indexOfConstructorCall(stackTraceElements);
-        return stackTraceElements[i + 1].getMethodName();
-    }
-
-    private int indexOfConstructorCall(StackTraceElement[] stackTraceElements) {
-        String className = getClass().getName();
-        for (int i = 0; i < stackTraceElements.length; i++) {
-            StackTraceElement element = stackTraceElements[i];
-            if (className.equals(element.getClassName()) && "<init>".equals(element.getMethodName())) {
-                return i;
-            }
-        }
-        return -1;
-    }
+public interface GUIComponent {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/GUIComponentFactory.java
+++ b/src/main/java/org/aludratest/service/gui/component/GUIComponentFactory.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component;
+
+import org.aludratest.service.locator.element.GUIElementLocator;
+import org.aludratest.service.locator.window.TitleLocator;
+
+/** Factory for creating components for a GUI service. You can retrieve the component factory for a given guiService by calling
+ * 
+ * <pre>
+ * guiService.getComponentFactory();
+ * </pre>
+ * 
+ * @author falbrech */
+public interface GUIComponentFactory {
+
+    /** Creates a new Button component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Button component for the given locator. */
+    public Button createButton(GUIElementLocator locator);
+
+    /** Creates a new Button component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Button component for the given locator. */
+    public Button createButton(GUIElementLocator locator, String elementName);
+
+    /** Creates a new Checkbox component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Checkbox component for the given locator. */
+    public Checkbox createCheckbox(GUIElementLocator locator);
+
+    /** Creates a new Checkbox component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Checkbox component for the given locator. */
+    public Checkbox createCheckbox(GUIElementLocator locator, String elementName);
+
+    /** Creates a new Dropdownbox component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Dropdownbox component for the given locator. */
+    public Dropdownbox createDropdownbox(GUIElementLocator locator);
+
+    /** Creates a new Dropdownbox component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Dropdownbox component for the given locator. */
+    public Dropdownbox createDropdownbox(GUIElementLocator locator, String elementName);
+
+    /** Creates a new FileField component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new FileField component for the given locator. */
+    public FileField createFileField(GUIElementLocator locator);
+
+    /** Creates a new FileField component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new FileField component for the given locator. */
+    public FileField createFileField(GUIElementLocator locator, String elementName);
+
+    /** Creates a new InputField component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new InputField component for the given locator. */
+    public InputField createInputField(GUIElementLocator locator);
+
+    /** Creates a new InputField component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new InputField component for the given locator. */
+    public InputField createInputField(GUIElementLocator locator, String elementName);
+
+    /** Creates a new Label component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Label component for the given locator. */
+    public Label createLabel(GUIElementLocator locator);
+
+    /** Creates a new Label component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Label component for the given locator. */
+    public Label createLabel(GUIElementLocator locator, String elementName);
+
+    /** Creates a new Link component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Link component for the given locator. */
+    public Link createLink(GUIElementLocator locator);
+
+    /** Creates a new Link component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Link component for the given locator. */
+    public Link createLink(GUIElementLocator locator, String elementName);
+
+    /** Creates a new RadioButton component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new RadioButton component for the given locator. */
+    public RadioButton createRadioButton(GUIElementLocator locator);
+
+    /** Creates a new RadioButton component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new RadioButton component for the given locator. */
+    public RadioButton createRadioButton(GUIElementLocator locator, String elementName);
+
+    /** Creates a new Window component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new Window component for the given locator. */
+    public Window createWindow(TitleLocator locator);
+
+    /** Creates a new Window component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new Window component for the given locator. */
+    public Window createWindow(TitleLocator locator, String elementName);
+
+    /** Creates a new generic element component for the given locator.
+     * 
+     * @param locator Locator for the new component.
+     * 
+     * @return A new generic element component for the given locator. */
+    public GenericElement createGenericElement(GUIElementLocator locator);
+
+    /** Creates a new generic element component for the given locator, carrying the given element name.
+     * 
+     * @param locator Locator for the new component.
+     * @param elementName Element name for the new component.
+     * 
+     * @return A new generic element component for the given locator. */
+    public GenericElement createGenericElement(GUIElementLocator locator, String elementName);
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/GenericElement.java
+++ b/src/main/java/org/aludratest/service/gui/component/GenericElement.java
@@ -15,28 +15,11 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
 
-/**
- * GUI element without a specific assignment to a certain GUI component type.
+/** GUI element without a specific assignment to a certain GUI component type.
+ * 
  * @author Volker Bergmann
- */
-public class GenericElement extends Element<GenericElement> {
-
-    /** Constructor.
-     * @param aludraGui the underlying AludraGUI instance
-     * @param locator a {@link GUIElementLocator} for localizing the associated GUI component */
-    public GenericElement(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     * @param aludraGui the underlying AludraGUI instance
-     * @param locator a {@link GUIElementLocator} for localizing the associated GUI component
-     * @param elementName the name by which to log element access */
-    public GenericElement(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
+ * @author falbrech */
+public interface GenericElement extends Element<GenericElement> {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/InputField.java
+++ b/src/main/java/org/aludratest/service/gui/component/InputField.java
@@ -15,36 +15,14 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
-import org.aludratest.util.data.helper.DataMarkerCheck;
-import org.databene.commons.Validator;
+import org.aludratest.service.gui.component.impl.ValueComponent;
 
 /**
  * Represents an input field in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann
  */
-public class InputField extends InputComponent<InputField> implements ValueComponent {
-
-    private ValueComponentHelper helper = new ValueComponentHelper(this, true);
-
-    /**
-     * Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced input field
-     */
-    public InputField(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     *  @param aludraGui the underlying {@link AludraGUI} service instance
-     *  @param locator a locator for the referenced element
-     *  @param elementName an explicit name to use for the component */
-    public InputField(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
+public interface InputField extends InputComponent<InputField>, ValueComponent {
 
     /**
      * Enters text in the InputField.
@@ -52,55 +30,6 @@ public class InputField extends InputComponent<InputField> implements ValueCompo
      * If the text is marked as empty it will be replaced with ""
      * @param text the text to enter in the input field
      */
-    public void enter(String text) {
-        if (!DataMarkerCheck.isNull(text)) {
-            perform().type(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(text), taskCompletionTimeout);
-        }
-    }
-
-    @Override
-    public String getText() {
-        return perform().getInputFieldValue(elementType, elementName, getLocator());
-    }
-
-    @Override
-    public void assertTextEquals(String expectedText) {
-        helper.assertTextEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextNotEquals(String expectedText) {
-        helper.assertTextNotEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextContains(String expectedText) {
-        helper.assertTextContains(expectedText);
-    }
-
-    @Override
-    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextMatches(Validator<String> validator) {
-        helper.assertTextMatches(validator);
-    }
-
-    @Override
-    public void assertValueGreaterThan(String value) {
-        helper.assertValueGreaterThan(value);
-    }
-
-    @Override
-    public void assertValueLessThan(String value) {
-        helper.assertValueLessThan(value);
-    }
+    public void enter(String text);
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Label.java
+++ b/src/main/java/org/aludratest/service/gui/component/Label.java
@@ -15,79 +15,13 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
-import org.databene.commons.Validator;
+import org.aludratest.service.gui.component.impl.ValueComponent;
 
 /**
  * Represents a Label in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann
  */
-public class Label extends Element<Label> implements ValueComponent {
-
-    private ValueComponentHelper helper = new ValueComponentHelper(this, false);
-
-    /**
-     * Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced label
-     */
-    public Label(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     *  @param aludraGui the underlying {@link AludraGUI} service instance
-     *  @param locator a locator for the referenced element
-     *  @param elementName an explicit name to use for the component */
-    public Label(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
-
-    @Override
-    public String getText() {
-        return helper.getText();
-    }
-
-    @Override
-    public void assertTextEquals(String expectedText) {
-        helper.assertTextEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextNotEquals(String expectedText) {
-        helper.assertTextNotEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextContains(String expectedText) {
-        helper.assertTextContains(expectedText);
-    }
-
-    @Override
-    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextMatches(Validator<String> validator) {
-        helper.assertTextMatches(validator);
-    }
-
-    @Override
-    public void assertValueGreaterThan(String value) {
-        helper.assertValueGreaterThan(value);
-    }
-
-    @Override
-    public void assertValueLessThan(String value) {
-        helper.assertValueLessThan(value);
-    }
+public interface Label extends Element<Label>, ValueComponent {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Link.java
+++ b/src/main/java/org/aludratest/service/gui/component/Link.java
@@ -15,85 +15,13 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.element.GUIElementLocator;
-import org.databene.commons.Validator;
+import org.aludratest.service.gui.component.impl.ValueComponent;
 
 /**
  * Represents a link in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann
  */
-public class Link extends Element<Link> implements ValueComponent {
-
-    private ValueComponentHelper helper = new ValueComponentHelper(this, false);
-
-    /**
-     * Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced link
-     */
-    public Link(AludraGUI aludraGui, GUIElementLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     *  @param aludraGui the underlying {@link AludraGUI} service instance
-     *  @param locator a locator for the referenced element
-     *  @param elementName an explicit name to use for the component */
-    public Link(AludraGUI aludraGui, GUIElementLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
-
-    /** Clicks the link. */
-    @Override
-    public void click() {
-        perform().click(elementType, elementName, getLocator(), taskCompletionTimeout);
-    }
-
-    @Override
-    public String getText() {
-        return helper.getText();
-    }
-
-    @Override
-    public void assertTextEquals(String expectedText) {
-        helper.assertTextEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextNotEquals(String expectedText) {
-        helper.assertTextNotEquals(expectedText);
-    }
-
-    @Override
-    public void assertTextContains(String expectedText) {
-        helper.assertTextContains(expectedText);
-    }
-
-    @Override
-    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
-        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
-    }
-
-    @Override
-    public void assertTextMatches(Validator<String> validator) {
-        helper.assertTextMatches(validator);
-    }
-
-    @Override
-    public void assertValueGreaterThan(String value) {
-        helper.assertValueGreaterThan(value);
-    }
-
-    @Override
-    public void assertValueLessThan(String value) {
-        helper.assertValueLessThan(value);
-    }
+public interface Link extends Element<Link>, ValueComponent {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/Window.java
+++ b/src/main/java/org/aludratest/service/gui/component/Window.java
@@ -15,39 +15,17 @@
  */
 package org.aludratest.service.gui.component;
 
-import org.aludratest.service.gui.AludraGUI;
-import org.aludratest.service.locator.window.TitleLocator;
 
 /**
  * Represents a Window/Frame in a GUI.
  * @author Joerg Langnickel
  * @author Volker Bergmann
  */
-public class Window extends GUIComponent {
+public interface Window extends GUIComponent {
 
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced window */
-    public Window(AludraGUI aludraGui, TitleLocator locator) {
-        super(aludraGui, locator);
-    }
-
-    /** Constructor.
-     * @param aludraGui the underlying {@link AludraGUI} service instance
-     * @param locator a locator for the referenced element
-     * @param elementName an explicit name to use for the window */
-    public Window(AludraGUI aludraGui, TitleLocator locator, String elementName) {
-        super(aludraGui, locator, elementName);
-    }
-
-    /** @return the locator */
-    public TitleLocator getLocator() {
-        return (TitleLocator) locator;
-    }
-
-    /** Closes all other open windows. */
-    public void closeOthers() {
-        perform().closeOtherWindows(elementType, elementName, getLocator());
-    }
+    /**
+     * Closes all other open windows.
+     */
+    public void closeOthers();
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/AbstractElement.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/AbstractElement.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.AludraGUI;
+import org.aludratest.service.gui.component.Element;
+import org.aludratest.service.locator.element.GUIElementLocator;
+import org.aludratest.util.data.helper.DataMarkerCheck;
+
+/** Parent class for GUI Elements e.g. Button.
+ * 
+ * TODO document waitingUntilTaskCompletion feature
+ * 
+ * @author Joerg Langnickel
+ * @author Volker Bergmann
+ * @param <E> Type of the concrete element, to be used by subclasses. */
+public abstract class AbstractElement<E extends Element<E>> extends AbstractGUIComponent implements Element<E> {
+
+    protected int taskCompletionTimeout = -1;
+
+    @Override
+    public GUIElementLocator getLocator() {
+        return (GUIElementLocator) locator;
+    }
+
+    /** Activates the <i>waiting until task completion</i> feature on the underlying aludraGUI with the default value for the task
+     * completion timeout. */
+    @Override
+    public E waitingUntilTaskCompletion() {
+        return waitingUntilTaskCompletion(0);
+    }
+
+    /** Sets the {@link #taskCompletionTimeout} to the specified value.
+     * @param waitTime the wait time to apply. A negative number disables the wait feature, 0 implicitly activates the
+     *            {@link AludraGUI}'s default, a positive value is used as explicit timeout. */
+    @Override
+    @SuppressWarnings("unchecked")
+    public E waitingUntilTaskCompletion(int waitTime) {
+        this.taskCompletionTimeout = waitTime;
+        return (E) this;
+    }
+
+    /** Asserts that the element is editable. */
+    @Override
+    public void assertEditable() {
+        verify().assertEditable(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the element is not editable. */
+    @Override
+    public void assertNotEditable() {
+        verify().assertNotEditable(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the element is present */
+    @Override
+    public void assertPresent() {
+        verify().assertElementPresent(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the element is not present */
+    @Override
+    public void assertNotPresent() {
+        verify().assertElementNotPresent(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the element is visible */
+    @Override
+    public void assertVisible() {
+        verify().assertVisible(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the element has the focus. */
+    @Override
+    public void assertFocus() {
+        verify().assertHasFocus(elementType, elementName, getLocator());
+    }
+
+    /** Sets the focus on this element */
+    @Override
+    public void focus() {
+        perform().focus(elementType, elementName, getLocator());
+    }
+
+    /** Double clicks the element. */
+    @Override
+    public void doubleClick() {
+        perform().doubleClick(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Single-clicks the element. */
+    @Override
+    public void click() {
+        perform().click(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Selectable click- clicks only when provided string is not null, not marked as null and provided string is "true"
+     * @param click -String */
+    @Override
+    public void click(String click) {
+        if (!DataMarkerCheck.isNull(click)) {
+            if (Boolean.parseBoolean(click)) {
+                click();
+            }
+        }
+    }
+
+    /** Selectable not editable click - clicks only when provided string is not null, not marked as null and provided string is
+     * "true"
+     * @param click -String */
+    @Override
+    public void clickNotEditable(String click) {
+        if (!DataMarkerCheck.isNull(click)) {
+            if (Boolean.parseBoolean(click)) {
+                clickNotEditable();
+            }
+        }
+    }
+
+    /** Click on an element which is not editable (accept the non-editable state) */
+    @Override
+    public void clickNotEditable() {
+        perform().clickNotEditable(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Double click on an element which is not editable (accept the non-editable state) */
+    @Override
+    public void doubleClickNotEditable() {
+        perform().doubleClickNotEditable(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Checks if the specified element is somewhere on the page within the standard timeout.
+     * 
+     * @return <code>true</code> if the element was found present somewhere on the page within the standard timeout,
+     *         <code>false</code> otherwise. */
+    @Override
+    public boolean isPresent() {
+        return check().isElementPresent(elementType, elementName, getLocator());
+    }
+
+    /** Checks if the specified element is somewhere on the page and in foreground within the standard timeout.
+     * 
+     * @return <code>true</code> if the element was found present somewhere on the page and in foreground within the standard
+     *         timeout, <code>false</code> otherwise. */
+    @Override
+    public boolean isPresentAndInForeground() {
+        return check().isElementPresentandInForeground(elementType, elementName, getLocator());
+    }
+
+    /** Checks if the specified element is somewhere on the page within a given timeout
+     * 
+     * @param timeout max time to wait for the element to become present.
+     * @return <code>true</code> if the element was found present somewhere on the page within the given timeout,
+     *         <code>false</code> otherwise. */
+    @Override
+    public boolean isPresent(long timeout) {
+        return check().isElementPresent(elementType, elementName, getLocator(), timeout);
+    }
+
+    /** Checks if the specified element is nowhere on the page within the standard timeout.
+     * 
+     * @return <code>true</code> if the element was <b>not</b> found present somewhere on the page within the standard timeout,
+     *         <code>false</code> otherwise. */
+    @Override
+    public boolean isNotPresent() {
+        return check().isElementNotPresent(elementType, elementName, getLocator());
+    }
+
+    /** Checks if the specified element is nowhere on the page within the standard timeout.
+     * 
+     * @param timeout time to check for the element not being present.
+     * 
+     * @return <code>true</code> if the element was <b>not</b> found present somewhere on the page within the given timeout,
+     *         <code>false</code> otherwise. */
+    @Override
+    public boolean isNotPresent(long timeout) {
+        return check().isElementNotPresent(elementType, elementName, getLocator(), timeout);
+    }
+
+    /** Checks if the specified element is visible within the standard timeout.
+     * 
+     * @return <code>true</code> if the element is visible, <code>false</code> otherwise. */
+    @Override
+    public boolean isVisible() {
+        return check().isElementVisible(elementType, elementName, getLocator());
+    }
+
+    /** Checks if the specified element is visible within the given timeout.
+     * 
+     * @param timeout Max time to wait for the element to become visible.
+     * 
+     * @return <code>true</code> if the element was found visible during the given timeout, <code>false</code> otherwise. */
+    @Override
+    public boolean isVisible(long timeout) {
+        return check().isElementVisible(elementType, elementName, getLocator(), timeout);
+    }
+}
+

--- a/src/main/java/org/aludratest/service/gui/component/impl/AbstractGUIComponent.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/AbstractGUIComponent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.AludraGUI;
+import org.aludratest.service.gui.GUICondition;
+import org.aludratest.service.gui.GUIInteraction;
+import org.aludratest.service.gui.GUIVerification;
+import org.aludratest.service.gui.component.GUIComponent;
+import org.aludratest.service.locator.Locator;
+
+/** Parent class for all Components of a Graphical User Interface.
+ * @author Marcel Malitz
+ * @author Volker Bergmann */
+public abstract class AbstractGUIComponent implements GUIComponent {
+
+    protected AludraGUI aludraGui;
+    protected Locator locator;
+    protected String elementType;
+    protected String elementName;
+
+    protected final void configure(AludraGUI aludraGui, Locator locator, String elementType, String elementName) {
+        if (aludraGui == null) {
+            throw new IllegalArgumentException("aludraGui is null");
+        }
+        if (locator == null) {
+            throw new IllegalArgumentException("locator is null");
+        }
+        if (elementType == null) {
+            throw new IllegalArgumentException("elementType is null");
+        }
+
+        this.aludraGui = aludraGui;
+        this.locator = locator;
+        this.elementType = elementType;
+
+        // FIXME replace with clean logic
+        this.elementName = (elementName != null ? elementName : defaultElementName());
+    }
+
+    // utility methods for child classes ---------------------------------------
+
+    protected GUIInteraction perform() {
+        return aludraGui.perform();
+    }
+
+    protected GUIVerification verify() {
+        return aludraGui.verify();
+    }
+
+    protected GUICondition check() {
+        return aludraGui.check();
+    }
+
+    // private helpers ---------------------------------------------------------
+
+    private String defaultElementName() {
+        return "bla";
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/AbstractInputComponent.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/AbstractInputComponent.java
@@ -13,25 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
+import org.aludratest.service.gui.component.Element;
+import org.aludratest.service.gui.component.InputComponent;
 
-/** Interface for input components. Adds an enabled / disabled state to the component.
+/** Abstract base class for input components. Adds an enabled / disabled state to the component.
  * 
  * @author falbrech
- * @param <E> Type of concrete component. */
-public interface InputComponent<E extends Element<E>> extends Element<E> {
+ * @param <E> Type of concrete subclasses. */
+public abstract class AbstractInputComponent<E extends Element<E>> extends AbstractElement<E> implements InputComponent<E> {
 
     /** Checks whether this input element is enabled.
      * 
      * @return <code>true</code> if the input element is enabled, <code>false</code> otherwise. */
-    public boolean isEnabled();
+    @Override
+    public boolean isEnabled() {
+        return check().isElementEnabled(elementType, elementName, getLocator());
+    }
 
     /** Checks whether this input element is enabled.
      * 
      * @param timeout Max time to wait for this input element to become enabled.
      * 
      * @return <code>true</code> if the input element is enabled, <code>false</code> otherwise. */
-    public boolean isEnabled(long timeout);
+    @Override
+    public boolean isEnabled(long timeout) {
+        return check().isElementEnabled(elementType, elementName, getLocator(), timeout);
+    }
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/ButtonImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/ButtonImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.component.Button;
+import org.databene.commons.Validator;
+
+/** Default implementation of the Button interface.
+ * 
+ * @author falbrech */
+public class ButtonImpl extends AbstractInputComponent<Button> implements Button {
+
+    private ValueComponentHelper helper = new ValueComponentHelper(this, true);
+
+    @Override
+    public String getText() {
+        return helper.getText();
+    }
+
+    @Override
+    public void assertTextEquals(String expectedText) {
+        helper.assertTextEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextNotEquals(String expectedText) {
+        helper.assertTextNotEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextContains(String expectedText) {
+        helper.assertTextContains(expectedText);
+    }
+
+    @Override
+    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextMatches(Validator<String> validator) {
+        helper.assertTextMatches(validator);
+    }
+
+    @Override
+    public void assertValueGreaterThan(String value) {
+        helper.assertValueGreaterThan(value);
+    }
+
+    @Override
+    public void assertValueLessThan(String value) {
+        helper.assertValueLessThan(value);
+    }
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/CheckboxImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/CheckboxImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.component.Checkbox;
+import org.aludratest.util.data.helper.DataMarkerCheck;
+
+/** Default implementation of the Checkbox interface. */
+public class CheckboxImpl extends AbstractInputComponent<Checkbox> implements Checkbox {
+
+    /** Selects or deselects a Checkbox due to overgiven String If the text is null or marked as null the operation is not
+     * executed.
+     * @param selectString */
+    @Override
+    public void select(String selectString) {
+        if (!DataMarkerCheck.isNull(selectString)) {
+            Boolean select = Boolean.parseBoolean(selectString);
+            if (select) {
+                select();
+            }
+            else {
+                deselect();
+            }
+        }
+    }
+
+    /** Selects the checkbox. */
+    @Override
+    public void select() {
+        perform().selectCheckbox(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Unselects the checkbox. */
+    @Override
+    public void deselect() {
+        perform().deselectCheckbox(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    /** Asserts that the checkbox is checked. */
+    @Override
+    public void assertChecked() {
+        verify().assertChecked(elementType, elementName, getLocator());
+    }
+
+    /** Asserts that the checkbox is in the in the state expected by the passed text If the text is null or marked as null the
+     * operation is not executed.
+     * @param text <code>"true"</code> or <code>"false"</code>. Anything else (non-null) will be interpreted as <code>false</code> */
+    @Override
+    public void assertChecked(String text) {
+        if (!DataMarkerCheck.isNull(text)) {
+            Boolean expected = Boolean.parseBoolean(text);
+            verify().assertChecked(elementType, elementName, expected, getLocator());
+        }
+    }
+
+    /** Returns if the checkbox is currently checked or not.
+     * 
+     * @return <code>true</code> if the checkbox is currently checked (has a checkmark in its box), <code>false</code> otherwise. */
+    @Override
+    public boolean isChecked() {
+        return check().isElementChecked(elementType, elementName, getLocator());
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/DefaultGUIComponentFactory.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/DefaultGUIComponentFactory.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.aludratest.exception.TechnicalException;
+import org.aludratest.service.AludraContext;
+import org.aludratest.service.ComponentId;
 import org.aludratest.service.gui.AludraGUI;
 import org.aludratest.service.gui.component.Button;
 import org.aludratest.service.gui.component.Checkbox;
@@ -66,16 +68,18 @@ public class DefaultGUIComponentFactory implements GUIComponentFactory {
         componentImplClasses.put(Window.class, WindowImpl.class);
     }
 
-    private AludraGUI aludraGUI;
-
     @Requirement
     private PlexusContainer plexusContainer;
 
-    /** Sets the AludraGUI service to use for this component factory.
+    private AludraGUI aludraGUI;
+
+    /** Configures this component factory. It requires an AludraContext and a component ID to query the context for to get the
+     * AludraGUI service to use. This is required to get the dynamic proxy for the service, not the service itself.
      * 
-     * @param aludraGUI AludraGUI service to use. */
-    public void setAludraGUI(AludraGUI aludraGUI) {
-        this.aludraGUI = aludraGUI;
+     * @param context Aludra context to use.
+     * @param guiComponentId Component ID to query the context for to get an AludraGUI implementation. */
+    public void configureForGUIService(AludraContext context, ComponentId<? extends AludraGUI> guiComponentId) {
+        this.aludraGUI = context.getService(guiComponentId);
     }
 
     @Override

--- a/src/main/java/org/aludratest/service/gui/component/impl/DefaultGUIComponentFactory.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/DefaultGUIComponentFactory.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.aludratest.exception.TechnicalException;
+import org.aludratest.service.gui.AludraGUI;
+import org.aludratest.service.gui.component.Button;
+import org.aludratest.service.gui.component.Checkbox;
+import org.aludratest.service.gui.component.Dropdownbox;
+import org.aludratest.service.gui.component.FileField;
+import org.aludratest.service.gui.component.GUIComponent;
+import org.aludratest.service.gui.component.GUIComponentFactory;
+import org.aludratest.service.gui.component.GenericElement;
+import org.aludratest.service.gui.component.InputField;
+import org.aludratest.service.gui.component.Label;
+import org.aludratest.service.gui.component.Link;
+import org.aludratest.service.gui.component.RadioButton;
+import org.aludratest.service.gui.component.Window;
+import org.aludratest.service.locator.Locator;
+import org.aludratest.service.locator.element.GUIElementLocator;
+import org.aludratest.service.locator.window.TitleLocator;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.component.composition.CycleDetectedInComponentGraphException;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+/** Default implementation of the {@link GUIComponentFactory} interface. Uses Plexus to instantiate the components. GUI service
+ * implementors can subclass this class to provide own component implementor classes or additional component configuration.
+ * 
+ * @author falbrech */
+@Component(role = GUIComponentFactory.class, hint = "default")
+public class DefaultGUIComponentFactory implements GUIComponentFactory {
+
+    private static final Map<Class<? extends GUIComponent>, Class<? extends GUIComponent>> componentImplClasses = new HashMap<Class<? extends GUIComponent>, Class<? extends GUIComponent>>();
+    static {
+        componentImplClasses.put(Button.class, ButtonImpl.class);
+        componentImplClasses.put(Checkbox.class, CheckboxImpl.class);
+        componentImplClasses.put(Dropdownbox.class, DropdownboxImpl.class);
+        componentImplClasses.put(FileField.class, FileFieldImpl.class);
+        componentImplClasses.put(GenericElement.class, GenericElementImpl.class);
+        componentImplClasses.put(InputField.class, InputFieldImpl.class);
+        componentImplClasses.put(Label.class, LabelImpl.class);
+        componentImplClasses.put(Link.class, LinkImpl.class);
+        componentImplClasses.put(RadioButton.class, RadioButtonImpl.class);
+        componentImplClasses.put(Window.class, WindowImpl.class);
+    }
+
+    private AludraGUI aludraGUI;
+
+    @Requirement
+    private PlexusContainer plexusContainer;
+
+    /** Sets the AludraGUI service to use for this component factory.
+     * 
+     * @param aludraGUI AludraGUI service to use. */
+    public void setAludraGUI(AludraGUI aludraGUI) {
+        this.aludraGUI = aludraGUI;
+    }
+
+    @Override
+    public Button createButton(GUIElementLocator locator) {
+        return createComponent(Button.class, locator);
+    }
+
+    @Override
+    public Button createButton(GUIElementLocator locator, String elementName) {
+        return createComponent(Button.class, locator, elementName);
+    }
+
+    @Override
+    public Checkbox createCheckbox(GUIElementLocator locator) {
+        return createComponent(Checkbox.class, locator);
+    }
+
+    @Override
+    public Checkbox createCheckbox(GUIElementLocator locator, String elementName) {
+        return createComponent(Checkbox.class, locator, elementName);
+    }
+
+    @Override
+    public Dropdownbox createDropdownbox(GUIElementLocator locator) {
+        return createComponent(Dropdownbox.class, locator);
+    }
+
+    @Override
+    public Dropdownbox createDropdownbox(GUIElementLocator locator, String elementName) {
+        return createComponent(Dropdownbox.class, locator, elementName);
+    }
+
+    @Override
+    public FileField createFileField(GUIElementLocator locator) {
+        return createComponent(FileField.class, locator);
+    }
+
+    @Override
+    public FileField createFileField(GUIElementLocator locator, String elementName) {
+        return createComponent(FileField.class, locator, elementName);
+    }
+
+    @Override
+    public InputField createInputField(GUIElementLocator locator) {
+        return createComponent(InputField.class, locator);
+    }
+
+    @Override
+    public InputField createInputField(GUIElementLocator locator, String elementName) {
+        return createComponent(InputField.class, locator, elementName);
+    }
+
+    @Override
+    public Label createLabel(GUIElementLocator locator) {
+        return createComponent(Label.class, locator);
+    }
+
+    @Override
+    public Label createLabel(GUIElementLocator locator, String elementName) {
+        return createComponent(Label.class, locator, elementName);
+    }
+
+    @Override
+    public Link createLink(GUIElementLocator locator) {
+        return createComponent(Link.class, locator);
+    }
+
+    @Override
+    public Link createLink(GUIElementLocator locator, String elementName) {
+        return createComponent(Link.class, locator, elementName);
+    }
+
+    @Override
+    public RadioButton createRadioButton(GUIElementLocator locator) {
+        return createComponent(RadioButton.class, locator);
+    }
+
+    @Override
+    public RadioButton createRadioButton(GUIElementLocator locator, String elementName) {
+        return createComponent(RadioButton.class, locator, elementName);
+    }
+
+    @Override
+    public Window createWindow(TitleLocator locator) {
+        return createComponent(Window.class, locator);
+    }
+
+    @Override
+    public Window createWindow(TitleLocator locator, String elementName) {
+        return createComponent(Window.class, locator, elementName);
+    }
+
+    @Override
+    public GenericElement createGenericElement(GUIElementLocator locator) {
+        return createComponent(GenericElement.class, locator);
+    }
+
+    @Override
+    public GenericElement createGenericElement(GUIElementLocator locator, String elementName) {
+        return createComponent(GenericElement.class, locator, elementName);
+    }
+
+    /** Returns the implementor class for the given component class. Subclasses can override to specify own implementation classes,
+     * but you <b>must</b> also override {@link #getRoleHint()}.
+     * 
+     * @param componentClass Class of the component, e.g. <code>Button.class</code>.
+     * 
+     * @return The implementing component class, or <code>null</code> if no implementor class is available for the given component
+     *         class. Do <b>not</b> throw any exception; the calling method will deal with this. */
+    protected <T extends GUIComponent> Class<? extends T> getImplementorClass(Class<T> componentClass) {
+        @SuppressWarnings("unchecked")
+        Class<? extends T> implClass = (Class<? extends T>) componentImplClasses.get(componentClass);
+        return implClass;
+    }
+
+    /** Returns the role hint which is used by this component factory. If you want to register your own implementations of the
+     * component classes, you also have to override this method to avoid name clashes in the internal Plexus component registry.
+     * 
+     * @return The role hint to use for this component factory. */
+    protected String getRoleHint() {
+        return "default";
+    }
+
+    /** Configures the given freshly instantiated component to use the given identifiers. Subclasses can add more configuration
+     * logic, but should always invoke the super implementation.
+     * 
+     * @param component Component to configure.
+     * @param locator Locator to set in the component.
+     * @param componentClass Component class identifying the type of the component, e.g. <code>Button.class</code>.
+     * @param elementName Element name which was set in the factory method call or automatically determined if possible, or
+     *            <code>null</code>. */
+    protected void configureComponent(GUIComponent component, Locator locator, Class<?> componentClass, String elementName) {
+        if (component instanceof AbstractGUIComponent) {
+            ((AbstractGUIComponent) component).configure(aludraGUI, locator, componentClass.getSimpleName(), elementName);
+        }
+    }
+
+    protected final <T extends GUIComponent> T createComponent(Class<T> componentClass, Locator locator) {
+        return createComponent(componentClass, locator, determineDefaultElementName());
+    }
+
+    protected final <T extends GUIComponent> T createComponent(Class<T> componentClass, Locator locator, String elementName) {
+        Class<? extends T> implClass = getImplementorClass(componentClass);
+        if (implClass == null) {
+            throw new TechnicalException("No implementation class found for component class " + componentClass.getName());
+        }
+
+        try {
+            // check if Plexus container already "knows" this component class
+            if (plexusContainer.getComponentDescriptor(componentClass.getName(), getRoleHint()) == null) {
+                registerComponentDescriptor(componentClass, implClass);
+            }
+
+            T component = plexusContainer.lookup(componentClass, getRoleHint());
+            configureComponent(component, locator, componentClass, elementName);
+            return component;
+        }
+        catch (ComponentLookupException e) {
+            throw new TechnicalException("Could not create component of type " + componentClass.getSimpleName(), e);
+        }
+        catch (CycleDetectedInComponentGraphException e) {
+            throw new TechnicalException("Could not register component implementation of type " + componentClass.getSimpleName(),
+                    e);
+        }
+    }
+
+    private <T> void registerComponentDescriptor(Class<T> componentClass, Class<? extends T> implClass)
+            throws CycleDetectedInComponentGraphException {
+        ComponentDescriptor<T> desc = new ComponentDescriptor<T>();
+        desc.setRole(componentClass.getName());
+        desc.setRoleClass(componentClass);
+        desc.setRoleHint(getRoleHint());
+        desc.setImplementationClass(implClass);
+        desc.setIsolatedRealm(false);
+        desc.setInstantiationStrategy("per-lookup");
+
+        ClassRealm realm = plexusContainer.getLookupRealm();
+        if (realm == null) {
+            realm = plexusContainer.getContainerRealm();
+        }
+        desc.setRealm(realm);
+
+        // lookup Requirements in class
+        for (Field f : implClass.getDeclaredFields()) {
+            Requirement req = f.getAnnotation(Requirement.class);
+            if (req != null) {
+                desc.addRequirement(createComponentRequirement(f, req));
+            }
+        }
+
+        plexusContainer.addComponentDescriptor(desc);
+    }
+
+    private static ComponentRequirement createComponentRequirement(Field field, Requirement requirement) {
+        ComponentRequirement cr = new ComponentRequirement();
+        cr.setFieldName(field.getName());
+        cr.setOptional(requirement.optional());
+        if (requirement.role() != null && requirement.role() != Object.class) {
+            cr.setRole(requirement.role().getName());
+        }
+        else {
+            cr.setRole(field.getType().getName());
+        }
+        if (requirement.hint() != null) {
+            cr.setRoleHint(requirement.hint());
+        }
+
+        return cr;
+    }
+
+    private static String determineDefaultElementName() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        String lastMethodName = null;
+
+        for (StackTraceElement ste : stackTrace) {
+            String className = ste.getClassName();
+            if (className != null && className.contains("UIMap")) {
+                lastMethodName = ste.getMethodName();
+            }
+        }
+
+        // getCloseButton() => closeButton
+        if (lastMethodName != null && lastMethodName.startsWith("get") && lastMethodName.length() > 3) {
+            char ch = lastMethodName.charAt(3);
+            // could also be "getterButton()", so only remove when uppercase follows
+            if (Character.isUpperCase(ch)) {
+                lastMethodName = Character.toLowerCase(ch) + lastMethodName.substring(4);
+            }
+        }
+
+        return lastMethodName;
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/DropdownboxImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/DropdownboxImpl.java
@@ -15,6 +15,7 @@
  */
 package org.aludratest.service.gui.component.impl;
 
+import org.aludratest.service.gui.component.Dropdownbox;
 import org.aludratest.service.locator.option.IndexLocator;
 import org.aludratest.service.locator.option.LabelLocator;
 import org.aludratest.service.locator.option.OptionLocator;
@@ -26,12 +27,13 @@ import org.aludratest.util.validator.NotEqualsValidator;
 import org.databene.commons.Validator;
 
 /** Default implementation of the Dropdownbox interface. */
-public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
+public class DropdownboxImpl extends AbstractInputComponent<Dropdownbox> implements Dropdownbox {
 
     /** Selects an entry of this Dropdownbox by its label. If the label is <code>null</code> or marked as null, the operation is
      * not executed. It the label is marked as empty, it will be replaced with "".
      * 
      * @param label Label of the entry to select. */
+    @Override
     public void selectEntry(String label) {
         if (!DataMarkerCheck.isNull(label)) {
             selectEntry(new LabelLocator(DataMarkerCheck.convertIfEmpty(label)));
@@ -42,6 +44,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * 
      * @param optionLocator is a LabelLocator or IndexLocator for identifying the entry to select. If <code>null</code>, no action
      *            is performed. */
+    @Override
     public void selectEntry(OptionLocator optionLocator) {
         if (optionLocator != null) {
             perform().selectDropDownEntry(elementType, elementName, getLocator(), optionLocator, taskCompletionTimeout);
@@ -51,6 +54,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
     /** Reads the selected value and returns it as a String.
      * 
      * @return the <b>value</b> of the selected entry */
+    @Override
     public String getSelectedEntry() {
         return perform().getInputFieldValue(elementType, elementName, getLocator());
     }
@@ -58,6 +62,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
     /** Reads the selected label and returns it as a String.
      * 
      * @return the <b>label</b> of the selected entry */
+    @Override
     public String getSelectedLabel() {
         return perform().getInputFieldSelectedLabel(elementType, elementName, getLocator());
     }
@@ -66,6 +71,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * executed. If the label is marked as empty it will be replaced with ""
      * 
      * @param label Label to check the currently selected label against. */
+    @Override
     public void assertIsSelected(String label) {
         if (!DataMarkerCheck.isNull(label)) {
             verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
@@ -77,6 +83,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * operation is not executed. If the label is marked as empty it will be replaced with ""
      * 
      * @param label Label to check the currently selected label against. */
+    @Override
     public void assertTextNotEquals(String label) {
         if (!DataMarkerCheck.isNull(label)) {
             verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
@@ -88,6 +95,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * as null the operation is not executed.
      * 
      * @param label Label to check the currently selected label against. */
+    @Override
     public void assertSelectedContains(String label) {
         if (!DataMarkerCheck.isNull(label)) {
             verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(), new ContainsValidator(label));
@@ -99,6 +107,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * are ignored.
      * 
      * @param label Label to check the currently selected label against. */
+    @Override
     public void assertSelectedIgnoreCaseTrimmed(String label) {
         if (!DataMarkerCheck.isNull(label)) {
             verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
@@ -108,6 +117,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
 
     /** Asserts that the selection matches the provided {@link Validator}.
      * @param validator the validator to apply for verification */
+    @Override
     public void assertSelectionMatches(Validator<String> validator) {
         verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(), validator);
     }
@@ -116,6 +126,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * 
      * @param values Values to check the values of this Dropdownbox against. */
+    @Override
     public void assertHasValues(String... values) {
         if (values.length == 1) {
             String value1 = values[0];
@@ -139,6 +150,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * </ul>
      * If only one label is passed and it is <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * @param labels which should be checked */
+    @Override
     public void assertHasLabels(String... labels) {
         if (labels.length == 1) {
             String value1 = labels[0];
@@ -156,6 +168,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * 
      * @param labels Labels to check the labels of this Dropdownbox against. */
+    @Override
     public void assertContainsLabels(String... labels) {
         if (labels.length == 1) {
             String value1 = labels[0];
@@ -174,6 +187,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * @param labels Labels to check the labels of this Dropdownbox against.
      * 
      * @return <code>true</code> if the checkbox contains the given labels, <code>false</code> otherwise. */
+    @Override
     public boolean checkContainsLabels(String... labels) {
         return check().containsLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
     }
@@ -183,6 +197,7 @@ public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
      * @param labels Labels to check the labels of this Dropdownbox against.
      * 
      * @return <code>true</code> if the checkbox only contains the given labels, <code>false</code> otherwise. */
+    @Override
     public boolean checkEqualsLabels(String... labels) {
         return check().equalsLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
     }

--- a/src/main/java/org/aludratest/service/gui/component/impl/DropdownboxImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/DropdownboxImpl.java
@@ -13,74 +13,121 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
 import org.aludratest.service.locator.option.IndexLocator;
 import org.aludratest.service.locator.option.LabelLocator;
 import org.aludratest.service.locator.option.OptionLocator;
+import org.aludratest.util.data.helper.DataMarkerCheck;
+import org.aludratest.util.validator.ContainsValidator;
+import org.aludratest.util.validator.EqualsIgnoreCaseTrimmedValidator;
+import org.aludratest.util.validator.EqualsValidator;
+import org.aludratest.util.validator.NotEqualsValidator;
 import org.databene.commons.Validator;
 
-/** Represents a dropdownbox in a GUI.
- * @author Joerg Langnickel
- * @author Volker Bergmann */
-public interface Dropdownbox extends InputComponent<Dropdownbox> {
+/** Default implementation of the Dropdownbox interface. */
+public class DropdownboxImpl extends AbstractInputComponent<DropdownboxImpl> {
 
     /** Selects an entry of this Dropdownbox by its label. If the label is <code>null</code> or marked as null, the operation is
      * not executed. It the label is marked as empty, it will be replaced with "".
      * 
      * @param label Label of the entry to select. */
-    public void selectEntry(String label);
+    public void selectEntry(String label) {
+        if (!DataMarkerCheck.isNull(label)) {
+            selectEntry(new LabelLocator(DataMarkerCheck.convertIfEmpty(label)));
+        }
+    }
 
     /** Selects an entry of a Dropdownbox by its locator, which must be either a {@link LabelLocator} or an {@link IndexLocator}.
      * 
      * @param optionLocator is a LabelLocator or IndexLocator for identifying the entry to select. If <code>null</code>, no action
      *            is performed. */
-    public void selectEntry(OptionLocator optionLocator);
+    public void selectEntry(OptionLocator optionLocator) {
+        if (optionLocator != null) {
+            perform().selectDropDownEntry(elementType, elementName, getLocator(), optionLocator, taskCompletionTimeout);
+        }
+    }
 
     /** Reads the selected value and returns it as a String.
      * 
      * @return the <b>value</b> of the selected entry */
-    public String getSelectedEntry();
+    public String getSelectedEntry() {
+        return perform().getInputFieldValue(elementType, elementName, getLocator());
+    }
 
     /** Reads the selected label and returns it as a String.
      * 
      * @return the <b>label</b> of the selected entry */
-    public String getSelectedLabel();
+    public String getSelectedLabel() {
+        return perform().getInputFieldSelectedLabel(elementType, elementName, getLocator());
+    }
 
     /** Verifies that the passed label is selected in this Dropdownbox. If the label is null or marked as null the operation is not
      * executed. If the label is marked as empty it will be replaced with ""
      * 
      * @param label Label to check the currently selected label against. */
-    public void assertIsSelected(String label);
+    public void assertIsSelected(String label) {
+        if (!DataMarkerCheck.isNull(label)) {
+            verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
+                    new EqualsValidator(DataMarkerCheck.convertIfEmpty(label)));
+        }
+    }
 
     /** Verifies that the passed label is <b>not</b> selected in this Dropdownbox. If the label is null or marked as null the
      * operation is not executed. If the label is marked as empty it will be replaced with ""
      * 
      * @param label Label to check the currently selected label against. */
-    public void assertTextNotEquals(String label);
+    public void assertTextNotEquals(String label) {
+        if (!DataMarkerCheck.isNull(label)) {
+            verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
+                    new NotEqualsValidator(DataMarkerCheck.convertIfEmpty(label)));
+        }
+    }
 
     /** Verifies that the passed text is part of the currently selected label in this Dropdownbox. If the label is null or marked
      * as null the operation is not executed.
      * 
      * @param label Label to check the currently selected label against. */
-    public void assertSelectedContains(String label);
+    public void assertSelectedContains(String label) {
+        if (!DataMarkerCheck.isNull(label)) {
+            verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(), new ContainsValidator(label));
+        }
+    }
 
     /** Verifies that the passed label is selected in this Dropdownbox. If the label is null or marked as null the operation is not
      * executed. If the label is marked as empty it will be replaced with "". Differences in case, leading or trailing whitespace
      * are ignored.
      * 
      * @param label Label to check the currently selected label against. */
-    public void assertSelectedIgnoreCaseTrimmed(String label);
+    public void assertSelectedIgnoreCaseTrimmed(String label) {
+        if (!DataMarkerCheck.isNull(label)) {
+            verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(),
+                    new EqualsIgnoreCaseTrimmedValidator(DataMarkerCheck.convertIfEmpty(label)));
+        }
+    }
 
     /** Asserts that the selection matches the provided {@link Validator}.
      * @param validator the validator to apply for verification */
-    public void assertSelectionMatches(Validator<String> validator);
+    public void assertSelectionMatches(Validator<String> validator) {
+        verify().assertDropDownEntrySelectionMatches(elementType, elementName, getLocator(), validator);
+    }
 
     /** Verifies that this Dropdownbox has the passed through values (and only these). If only one value is passed and it is
      * <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * 
      * @param values Values to check the values of this Dropdownbox against. */
-    public void assertHasValues(String... values);
+    public void assertHasValues(String... values) {
+        if (values.length == 1) {
+            String value1 = values[0];
+            if (!DataMarkerCheck.isNull(value1)) {
+                verify().assertHasValues(elementType, elementName, getLocator(),
+                        new String[] { DataMarkerCheck.convertIfEmpty(value1) });
+            }
+        }
+        else {
+            verify().assertHasValues(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(values));
+        }
+    }
 
     /** Checks if this Dropdownbox has the expected labels.
      * 
@@ -92,26 +139,52 @@ public interface Dropdownbox extends InputComponent<Dropdownbox> {
      * </ul>
      * If only one label is passed and it is <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * @param labels which should be checked */
-    public void assertHasLabels(String... labels);
+    public void assertHasLabels(String... labels) {
+        if (labels.length == 1) {
+            String value1 = labels[0];
+            if (!DataMarkerCheck.isNull(value1)) {
+                verify().assertHasLabels(elementType, elementName, getLocator(),
+                        new String[] { DataMarkerCheck.convertIfEmpty(value1) });
+            }
+        }
+        else {
+            verify().assertHasLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
+        }
+    }
 
     /** Verifies that this Dropdownbox has the given labels (and possibly more than these). If only one value is passed and it is
      * <code>null</code> or marked as <code>null</code>, the operation will not be executed.
      * 
      * @param labels Labels to check the labels of this Dropdownbox against. */
-    public void assertContainsLabels(String... labels);
+    public void assertContainsLabels(String... labels) {
+        if (labels.length == 1) {
+            String value1 = labels[0];
+            if (!DataMarkerCheck.isNull(value1)) {
+                verify().assertHasLabels(elementType, elementName, getLocator(),
+                        new String[] { DataMarkerCheck.convertIfEmpty(value1) });
+            }
+        }
+        else {
+            verify().assertContainsLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
+        }
+    }
 
     /** Checks if this Dropdownbox has the given labels (and possibly more than these).
      * 
      * @param labels Labels to check the labels of this Dropdownbox against.
      * 
      * @return <code>true</code> if the checkbox contains the given labels, <code>false</code> otherwise. */
-    public boolean checkContainsLabels(String... labels);
+    public boolean checkContainsLabels(String... labels) {
+        return check().containsLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
+    }
 
     /** Checks if this Dropdownbox has ONLY the given labels - in the order as speficied.
      * 
      * @param labels Labels to check the labels of this Dropdownbox against.
      * 
      * @return <code>true</code> if the checkbox only contains the given labels, <code>false</code> otherwise. */
-    public boolean checkEqualsLabels(String... labels);
+    public boolean checkEqualsLabels(String... labels) {
+        return check().equalsLabels(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(labels));
+    }
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/FileFieldImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/FileFieldImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.aludratest.exception.AutomationException;
+import org.aludratest.service.gui.component.FileField;
+import org.aludratest.util.data.helper.DataMarkerCheck;
+import org.databene.commons.IOUtil;
+import org.databene.commons.Validator;
+
+/** Default implementation of the FileField interface. */
+public class FileFieldImpl extends AbstractInputComponent<FileField> implements ValueComponent {
+
+    private ValueComponentHelper helper = new ValueComponentHelper(this, true);
+
+    /** Saves the {@link InputStream}'s content in a new file with the given name.
+     * @param fileName the name by which to save the file
+     * @param in the provider of the file content to save */
+    public void setResourceNameAndContent(String fileName, InputStream in) {
+        if (!DataMarkerCheck.isNull(fileName)) {
+            File tempFile = getTestResourceFile(fileName);
+            try {
+                saveStreamContent(in, tempFile);
+                assignFileResource(fileName);
+            }
+            catch (IOException e) {
+                throw new AutomationException("Error ", e);
+            }
+        }
+    }
+
+    @Override
+    public String getText() {
+        return perform().getInputFieldValue(elementType, elementName, getLocator());
+    }
+
+    @Override
+    public void assertTextEquals(String expectedText) {
+        helper.assertTextEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextNotEquals(String expectedText) {
+        helper.assertTextNotEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextContains(String expectedText) {
+        helper.assertTextContains(expectedText);
+    }
+
+    @Override
+    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextMatches(Validator<String> validator) {
+        helper.assertTextMatches(validator);
+    }
+
+    @Override
+    public void assertValueGreaterThan(String value) {
+        helper.assertValueGreaterThan(value);
+    }
+
+    @Override
+    public void assertValueLessThan(String value) {
+        helper.assertValueLessThan(value);
+    }
+
+    private void saveStreamContent(InputStream in, File tempFile) throws FileNotFoundException, IOException {
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(tempFile);
+            IOUtil.transfer(in, out);
+        }
+        finally {
+            IOUtil.close(out);
+        }
+    }
+
+    /** Enters text in the InputField. If the text is null or marked as null the operation will not be executed If the text is
+     * marked as empty it will be replaced with ""
+     * @param fileName the name of the file to assign to the file field */
+    private void assignFileResource(String fileName) {
+        if (!DataMarkerCheck.isNull(fileName)) {
+            String filePath = getTestResourceFile(fileName).getAbsolutePath();
+            perform().assignFileResource(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(filePath),
+                    taskCompletionTimeout);
+        }
+    }
+
+    private File getTestResourceFile(String fileName) {
+        return new File(getTestResourceFolder(), fileName);
+    }
+
+    private File getTestResourceFolder() {
+        return new File("target/classes");
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/FileFieldImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/FileFieldImpl.java
@@ -28,13 +28,14 @@ import org.databene.commons.IOUtil;
 import org.databene.commons.Validator;
 
 /** Default implementation of the FileField interface. */
-public class FileFieldImpl extends AbstractInputComponent<FileField> implements ValueComponent {
+public class FileFieldImpl extends AbstractInputComponent<FileField> implements ValueComponent, FileField {
 
     private ValueComponentHelper helper = new ValueComponentHelper(this, true);
 
     /** Saves the {@link InputStream}'s content in a new file with the given name.
      * @param fileName the name by which to save the file
      * @param in the provider of the file content to save */
+    @Override
     public void setResourceNameAndContent(String fileName, InputStream in) {
         if (!DataMarkerCheck.isNull(fileName)) {
             File tempFile = getTestResourceFile(fileName);

--- a/src/main/java/org/aludratest/service/gui/component/impl/GenericElementImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/GenericElementImpl.java
@@ -18,6 +18,6 @@ package org.aludratest.service.gui.component.impl;
 import org.aludratest.service.gui.component.GenericElement;
 
 /** Default implementation of the GenericElement interface. */
-public class GenericElementImpl extends AbstractElement<GenericElement> {
+public class GenericElementImpl extends AbstractElement<GenericElement> implements GenericElement {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/GenericElementImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/GenericElementImpl.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
-import java.io.InputStream;
+import org.aludratest.service.gui.component.GenericElement;
 
-import org.aludratest.service.gui.component.impl.ValueComponent;
-
-/** Represents a file field in a GUI.
- * @author Volker Bergmann */
-public interface FileField extends InputComponent<FileField>, ValueComponent {
-
-    /** Saves the {@link InputStream}'s content in a new file with the given name.
-     * @param fileName the name by which to save the file
-     * @param in the provider of the file content to save */
-    public void setResourceNameAndContent(String fileName, InputStream in);
+/** Default implementation of the GenericElement interface. */
+public class GenericElementImpl extends AbstractElement<GenericElement> {
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/InputFieldImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/InputFieldImpl.java
@@ -20,7 +20,7 @@ import org.aludratest.util.data.helper.DataMarkerCheck;
 import org.databene.commons.Validator;
 
 /** Default implementation of the InputField interface. */
-public class InputFieldImpl extends AbstractInputComponent<InputField> implements ValueComponent {
+public class InputFieldImpl extends AbstractInputComponent<InputField> implements ValueComponent, InputField {
 
     private ValueComponentHelper helper = new ValueComponentHelper(this, true);
 
@@ -30,6 +30,7 @@ public class InputFieldImpl extends AbstractInputComponent<InputField> implement
      * If the text is marked as empty it will be replaced with ""
      * @param text the text to enter in the input field
      */
+    @Override
     public void enter(String text) {
         if (!DataMarkerCheck.isNull(text)) {
             perform().type(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(text), taskCompletionTimeout);

--- a/src/main/java/org/aludratest/service/gui/component/impl/InputFieldImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/InputFieldImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.component.InputField;
+import org.aludratest.util.data.helper.DataMarkerCheck;
+import org.databene.commons.Validator;
+
+/** Default implementation of the InputField interface. */
+public class InputFieldImpl extends AbstractInputComponent<InputField> implements ValueComponent {
+
+    private ValueComponentHelper helper = new ValueComponentHelper(this, true);
+
+    /**
+     * Enters text in the InputField.
+     * If the text is null or marked as null the operation will not be executed
+     * If the text is marked as empty it will be replaced with ""
+     * @param text the text to enter in the input field
+     */
+    public void enter(String text) {
+        if (!DataMarkerCheck.isNull(text)) {
+            perform().type(elementType, elementName, getLocator(), DataMarkerCheck.convertIfEmpty(text), taskCompletionTimeout);
+        }
+    }
+
+    @Override
+    public String getText() {
+        return perform().getInputFieldValue(elementType, elementName, getLocator());
+    }
+
+    @Override
+    public void assertTextEquals(String expectedText) {
+        helper.assertTextEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextNotEquals(String expectedText) {
+        helper.assertTextNotEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextContains(String expectedText) {
+        helper.assertTextContains(expectedText);
+    }
+
+    @Override
+    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextMatches(Validator<String> validator) {
+        helper.assertTextMatches(validator);
+    }
+
+    @Override
+    public void assertValueGreaterThan(String value) {
+        helper.assertValueGreaterThan(value);
+    }
+
+    @Override
+    public void assertValueLessThan(String value) {
+        helper.assertValueLessThan(value);
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/LabelImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/LabelImpl.java
@@ -19,7 +19,7 @@ import org.aludratest.service.gui.component.Label;
 import org.databene.commons.Validator;
 
 /** Default implementation of the Label interface. */
-public class LabelImpl extends AbstractElement<Label> implements ValueComponent {
+public class LabelImpl extends AbstractElement<Label> implements ValueComponent, Label {
 
     private ValueComponentHelper helper = new ValueComponentHelper(this, false);
 

--- a/src/main/java/org/aludratest/service/gui/component/impl/LabelImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/LabelImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.component.Label;
+import org.databene.commons.Validator;
+
+/** Default implementation of the Label interface. */
+public class LabelImpl extends AbstractElement<Label> implements ValueComponent {
+
+    private ValueComponentHelper helper = new ValueComponentHelper(this, false);
+
+    @Override
+    public String getText() {
+        return helper.getText();
+    }
+
+    @Override
+    public void assertTextEquals(String expectedText) {
+        helper.assertTextEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextNotEquals(String expectedText) {
+        helper.assertTextNotEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextContains(String expectedText) {
+        helper.assertTextContains(expectedText);
+    }
+
+    @Override
+    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextMatches(Validator<String> validator) {
+        helper.assertTextMatches(validator);
+    }
+
+    @Override
+    public void assertValueGreaterThan(String value) {
+        helper.assertValueGreaterThan(value);
+    }
+
+    @Override
+    public void assertValueLessThan(String value) {
+        helper.assertValueLessThan(value);
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/LinkImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/LinkImpl.java
@@ -19,7 +19,7 @@ import org.aludratest.service.gui.component.Link;
 import org.databene.commons.Validator;
 
 /** Default implementation of the Link interface. */
-public class LinkImpl extends AbstractElement<Link> implements ValueComponent {
+public class LinkImpl extends AbstractElement<Link> implements ValueComponent, Link {
 
     private ValueComponentHelper helper = new ValueComponentHelper(this, false);
 

--- a/src/main/java/org/aludratest/service/gui/component/impl/LinkImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/LinkImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.component.impl;
+
+import org.aludratest.service.gui.component.Link;
+import org.databene.commons.Validator;
+
+/** Default implementation of the Link interface. */
+public class LinkImpl extends AbstractElement<Link> implements ValueComponent {
+
+    private ValueComponentHelper helper = new ValueComponentHelper(this, false);
+
+    /** Clicks the link. */
+    @Override
+    public void click() {
+        perform().click(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
+
+    @Override
+    public String getText() {
+        return helper.getText();
+    }
+
+    @Override
+    public void assertTextEquals(String expectedText) {
+        helper.assertTextEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextNotEquals(String expectedText) {
+        helper.assertTextNotEquals(expectedText);
+    }
+
+    @Override
+    public void assertTextContains(String expectedText) {
+        helper.assertTextContains(expectedText);
+    }
+
+    @Override
+    public void assertTextContainsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextContainsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextEqualsIgnoreCaseTrimmed(String expectedText) {
+        helper.assertTextEqualsIgnoreCaseTrimmed(expectedText);
+    }
+
+    @Override
+    public void assertTextMatches(Validator<String> validator) {
+        helper.assertTextMatches(validator);
+    }
+
+    @Override
+    public void assertValueGreaterThan(String value) {
+        helper.assertValueGreaterThan(value);
+    }
+
+    @Override
+    public void assertValueLessThan(String value) {
+        helper.assertValueLessThan(value);
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/component/impl/RadioButtonImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/RadioButtonImpl.java
@@ -13,33 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
+import org.aludratest.service.gui.component.RadioButton;
+import org.aludratest.util.data.helper.DataMarkerCheck;
 
-/**
- * Represents a radio button on a GUI.
- * @author Joerg Langnickel
- * @author Volker Bergmann
- */
-public interface RadioButton extends InputComponent<RadioButton> {
+/** Default implementation of the RadioButton interface. */
+public class RadioButtonImpl extends AbstractInputComponent<RadioButton> {
 
     /** Selects this radio button. */
-    public void select();
+    public void select() {
+        perform().selectRadiobutton(elementType, elementName, getLocator(), taskCompletionTimeout);
+    }
 
     /** Selects this radio button if and only if the passed string parameter has the value <code>"true"</code>. In every other
      * case, no action is performed.
      * 
      * @param value String parameter to indicate if a select operation shall be performed on this radio button. */
-    public void select(String value);
+    public void select(String value) {
+        if (!DataMarkerCheck.isNull(value)) {
+            if (Boolean.parseBoolean(value)) {
+                select();
+            }
+        }
+    }
 
     /** Asserts that the radio button is checked */
-    public void assertChecked();
+    public void assertChecked() {
+        verify().assertChecked(elementType, elementName, getLocator());
+    }
 
     /** Asserts that this Radio button is in the expected state, passed by expected string. If the expected string is null or
      * marked as null, no operation will be executed.
      * 
      * @param expected <code>"true"</code> or <code>"false"</code>, or <code>null</code> or marked as null to not perform any
      *            assertion. */
-    public void assertChecked(String expected);
+    public void assertChecked(String expected) {
+        if (!DataMarkerCheck.isNull(expected)) {
+            verify().assertChecked(elementType, elementName, Boolean.parseBoolean(expected), getLocator());
+        }
+    }
 
 }

--- a/src/main/java/org/aludratest/service/gui/component/impl/RadioButtonImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/RadioButtonImpl.java
@@ -19,9 +19,10 @@ import org.aludratest.service.gui.component.RadioButton;
 import org.aludratest.util.data.helper.DataMarkerCheck;
 
 /** Default implementation of the RadioButton interface. */
-public class RadioButtonImpl extends AbstractInputComponent<RadioButton> {
+public class RadioButtonImpl extends AbstractInputComponent<RadioButton> implements RadioButton {
 
     /** Selects this radio button. */
+    @Override
     public void select() {
         perform().selectRadiobutton(elementType, elementName, getLocator(), taskCompletionTimeout);
     }
@@ -30,6 +31,7 @@ public class RadioButtonImpl extends AbstractInputComponent<RadioButton> {
      * case, no action is performed.
      * 
      * @param value String parameter to indicate if a select operation shall be performed on this radio button. */
+    @Override
     public void select(String value) {
         if (!DataMarkerCheck.isNull(value)) {
             if (Boolean.parseBoolean(value)) {
@@ -39,6 +41,7 @@ public class RadioButtonImpl extends AbstractInputComponent<RadioButton> {
     }
 
     /** Asserts that the radio button is checked */
+    @Override
     public void assertChecked() {
         verify().assertChecked(elementType, elementName, getLocator());
     }
@@ -48,6 +51,7 @@ public class RadioButtonImpl extends AbstractInputComponent<RadioButton> {
      * 
      * @param expected <code>"true"</code> or <code>"false"</code>, or <code>null</code> or marked as null to not perform any
      *            assertion. */
+    @Override
     public void assertChecked(String expected) {
         if (!DataMarkerCheck.isNull(expected)) {
             verify().assertChecked(elementType, elementName, Boolean.parseBoolean(expected), getLocator());

--- a/src/main/java/org/aludratest/service/gui/component/impl/ValueComponent.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/ValueComponent.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
 import org.databene.commons.Validator;
 

--- a/src/main/java/org/aludratest/service/gui/component/impl/ValueComponentHelper.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/ValueComponentHelper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
 import org.aludratest.util.data.helper.DataMarkerCheck;
 import org.aludratest.util.validator.ContainsIgnoreCaseTrimmedValidator;
@@ -30,11 +30,11 @@ import org.databene.commons.Validator;
  * @author falbrech */
 class ValueComponentHelper implements ValueComponent {
 
-    private Element<?> component;
-
     private boolean value;
 
-    ValueComponentHelper(Element<?> component, boolean value) {
+    private AbstractElement<?> component;
+
+    ValueComponentHelper(AbstractElement<?> component, boolean value) {
         this.component = component;
         this.value = value;
     }
@@ -121,7 +121,7 @@ class ValueComponentHelper implements ValueComponent {
     public void assertTextMatches(Validator<String> validator) {
         if (value) {
             component.verify()
-                    .assertValueMatches(component.elementType, component.elementName, component.getLocator(), validator);
+            .assertValueMatches(component.elementType, component.elementName, component.getLocator(), validator);
         }
         else {
             component.verify().assertTextMatches(component.elementType, component.elementName, component.getLocator(), validator);

--- a/src/main/java/org/aludratest/service/gui/component/impl/WindowImpl.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/WindowImpl.java
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aludratest.service.gui.component;
+package org.aludratest.service.gui.component.impl;
 
-import java.io.InputStream;
+import org.aludratest.service.gui.component.Window;
+import org.aludratest.service.locator.window.TitleLocator;
 
-import org.aludratest.service.gui.component.impl.ValueComponent;
+/** Default implementation of the Window interface. */
+public class WindowImpl extends AbstractGUIComponent implements Window {
 
-/** Represents a file field in a GUI.
- * @author Volker Bergmann */
-public interface FileField extends InputComponent<FileField>, ValueComponent {
-
-    /** Saves the {@link InputStream}'s content in a new file with the given name.
-     * @param fileName the name by which to save the file
-     * @param in the provider of the file content to save */
-    public void setResourceNameAndContent(String fileName, InputStream in);
+    /**
+     * Closes all other open windows.
+     */
+    @Override
+    public void closeOthers() {
+        perform().closeOtherWindows(elementType, elementName, (TitleLocator) locator);
+    }
 
 }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
@@ -19,7 +19,9 @@ import org.aludratest.config.ConfigProperties;
 import org.aludratest.config.ConfigProperty;
 import org.aludratest.config.Preferences;
 import org.aludratest.service.AbstractConfigurableAludraService;
+import org.aludratest.service.gui.component.GUIComponentFactory;
 import org.aludratest.service.gui.web.AludraWebGUI;
+import org.codehaus.plexus.component.annotations.Requirement;
 
 /** Common base class for Selenium based implementations of the AludraWebGUI interface.
  * 
@@ -42,6 +44,9 @@ public abstract class AbstractSeleniumService extends AbstractConfigurableAludra
 
     protected SeleniumWrapperConfiguration configuration;
 
+    @Requirement(hint = "default")
+    private GUIComponentFactory componentFactory;
+
     @Override
     public final String getPropertiesBaseName() {
         return "seleniumWrapper";
@@ -50,6 +55,11 @@ public abstract class AbstractSeleniumService extends AbstractConfigurableAludra
     @Override
     public final void configure(Preferences preferences) {
         configuration = new SeleniumWrapperConfiguration(preferences);
+    }
+
+    @Override
+    public GUIComponentFactory getComponentFactory() {
+        return componentFactory;
     }
 
 }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
@@ -19,6 +19,7 @@ import org.aludratest.config.ConfigProperties;
 import org.aludratest.config.ConfigProperty;
 import org.aludratest.config.Preferences;
 import org.aludratest.service.AbstractConfigurableAludraService;
+import org.aludratest.service.ComponentId;
 import org.aludratest.service.gui.component.GUIComponentFactory;
 import org.aludratest.service.gui.component.impl.DefaultGUIComponentFactory;
 import org.aludratest.service.gui.web.AludraWebGUI;
@@ -48,6 +49,8 @@ public abstract class AbstractSeleniumService extends AbstractConfigurableAludra
     @Requirement(hint = "default")
     private GUIComponentFactory componentFactory;
 
+    private boolean componentFactoryConfigured;
+
     @Override
     public final String getPropertiesBaseName() {
         return "seleniumWrapper";
@@ -56,11 +59,16 @@ public abstract class AbstractSeleniumService extends AbstractConfigurableAludra
     @Override
     public final void configure(Preferences preferences) {
         configuration = new SeleniumWrapperConfiguration(preferences);
-        ((DefaultGUIComponentFactory) componentFactory).setAludraGUI(this);
     }
 
     @Override
     public GUIComponentFactory getComponentFactory() {
+        if (!componentFactoryConfigured) {
+            ComponentId<AludraWebGUI> componentId = ComponentId
+                    .create(AludraWebGUI.class, aludraServiceContext.getInstanceName());
+            ((DefaultGUIComponentFactory) componentFactory).configureForGUIService(aludraServiceContext, componentId);
+            componentFactoryConfigured = true;
+        }
         return componentFactory;
     }
 

--- a/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/AbstractSeleniumService.java
@@ -20,6 +20,7 @@ import org.aludratest.config.ConfigProperty;
 import org.aludratest.config.Preferences;
 import org.aludratest.service.AbstractConfigurableAludraService;
 import org.aludratest.service.gui.component.GUIComponentFactory;
+import org.aludratest.service.gui.component.impl.DefaultGUIComponentFactory;
 import org.aludratest.service.gui.web.AludraWebGUI;
 import org.codehaus.plexus.component.annotations.Requirement;
 
@@ -55,6 +56,7 @@ public abstract class AbstractSeleniumService extends AbstractConfigurableAludra
     @Override
     public final void configure(Preferences preferences) {
         configuration = new SeleniumWrapperConfiguration(preferences);
+        ((DefaultGUIComponentFactory) componentFactory).setAludraGUI(this);
     }
 
     @Override

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumWrapper.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumWrapper.java
@@ -19,7 +19,7 @@ import org.aludratest.exception.AutomationException;
 import org.aludratest.exception.FunctionalFailure;
 import org.aludratest.exception.TechnicalException;
 import org.aludratest.service.SystemConnector;
-import org.aludratest.service.gui.component.Link;
+import org.aludratest.service.gui.component.impl.LinkImpl;
 import org.aludratest.service.gui.web.selenium.ConditionCheck;
 import org.aludratest.service.gui.web.selenium.ElementCommand;
 import org.aludratest.service.gui.web.selenium.SeleniumResourceService;
@@ -773,7 +773,7 @@ public class SeleniumWrapper {
     }
 
     private boolean isCalledByLink() {
-        return isCalledBy(Link.class);
+        return isCalledBy(LinkImpl.class);
     }
 
     private void waitForWindow(final WindowLocator windowLocator) {

--- a/src/main/java/org/aludratest/service/impl/AludraServiceManagerImpl.java
+++ b/src/main/java/org/aludratest/service/impl/AludraServiceManagerImpl.java
@@ -76,13 +76,16 @@ public class AludraServiceManagerImpl implements AludraServiceManager {
         cd.setInstantiationStrategy(isSingleton(iface) ? "singleton" : "per-lookup");
         cd.setRealm(realm);
 
-        // lookup Requirements in class
-        Class<?> implClassClass = realm.loadClass(implClass);
-        for (Field f : implClassClass.getDeclaredFields()) {
-            Requirement req = f.getAnnotation(Requirement.class);
-            if (req != null) {
-                cd.addRequirement(createComponentRequirement(f, req));
+        // lookup Requirements in class and parent classes
+        Class<?> clazz = realm.loadClass(implClass);
+        while (clazz != null && clazz != Object.class) {
+            for (Field f : clazz.getDeclaredFields()) {
+                Requirement req = f.getAnnotation(Requirement.class);
+                if (req != null) {
+                    cd.addRequirement(createComponentRequirement(f, req));
+                }
             }
+            clazz = clazz.getSuperclass();
         }
 
         return cd;

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -67,6 +67,20 @@
       </requirements>
     </component>
     <component>
+      <role>org.aludratest.service.gui.component.GUIComponentFactory</role>
+      <role-hint>default</role-hint>
+      <implementation>org.aludratest.service.gui.component.impl.DefaultGUIComponentFactory</implementation>
+      <description></description>
+      <isolated-realm>false</isolated-realm>
+      <requirements>
+        <requirement>
+          <role>org.codehaus.plexus.PlexusContainer</role>
+          <role-hint></role-hint>
+          <field-name>plexusContainer</field-name>
+        </requirement>
+      </requirements>
+    </component>
+    <component>
       <role>org.aludratest.service.AludraServiceManager</role>
       <role-hint>default</role-hint>
       <implementation>org.aludratest.service.impl.AludraServiceManagerImpl</implementation>

--- a/src/test/java/org/aludratest/service/gitclient/GitClientIntegrationTest.java
+++ b/src/test/java/org/aludratest/service/gitclient/GitClientIntegrationTest.java
@@ -50,12 +50,14 @@ import org.databene.commons.IOUtil;
 import org.databene.commons.StringUtil;
 import org.databene.commons.SystemInfo;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.internal.AssumptionViolatedException;
 
 /** Tests the {@link GitClient} against an installation of git.
  * @author Volker Bergmann */
 @SuppressWarnings("javadoc")
+@Ignore
 public class GitClientIntegrationTest extends AbstractAludraServiceTest {
 
     private static final String ADDED_FILE = "added.txt";

--- a/src/test/java/org/aludratest/service/gui/component/base/AbstractIFrameTest.java
+++ b/src/test/java/org/aludratest/service/gui/component/base/AbstractIFrameTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractIFrameTest extends GUITest {
         }
 
         public Button findButton() {
-            return new Button(aludraGUI, new IdLocator("findbutton"));
+            return aludraGUI.getComponentFactory().createButton(new IdLocator("findbutton"));
         }
 
     }

--- a/src/test/java/org/aludratest/service/gui/component/base/GUITestUIMap.java
+++ b/src/test/java/org/aludratest/service/gui/component/base/GUITestUIMap.java
@@ -82,99 +82,99 @@ public class GUITestUIMap extends UIMap {
     }
 
     public Dropdownbox dropDownBox() {
-        return new Dropdownbox(aludraGUI, DROPDOWNBOX_ID);
+        return aludraGUI.getComponentFactory().createDropdownbox(DROPDOWNBOX_ID);
     }
 
     public Dropdownbox disabledDropDownBox() {
-        return new Dropdownbox(aludraGUI, DISABLED_DROPDOWNBOX_ID);
+        return aludraGUI.getComponentFactory().createDropdownbox(DISABLED_DROPDOWNBOX_ID);
     }
 
     public InputField textField() {
-        return new InputField(aludraGUI, TEXT_FIELD_ID);
+        return aludraGUI.getComponentFactory().createInputField(TEXT_FIELD_ID);
     }
 
     public InputField noidTextField() {
-        return new InputField(aludraGUI, NOID_TEXT_FIELD);
+        return aludraGUI.getComponentFactory().createInputField(NOID_TEXT_FIELD);
     }
 
     public InputField disabledTextField() {
-        return new InputField(aludraGUI, DISABLED_TEXT_FIELD_ID);
+        return aludraGUI.getComponentFactory().createInputField(DISABLED_TEXT_FIELD_ID);
     }
 
     public Button findButton() {
-        return new Button(aludraGUI, FIND_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(FIND_BUTTON_ID);
     }
 
     public Button findButtonWithTimeout() {
-        return new Button(aludraGUI, FIND_BUTTON_ID).waitingUntilTaskCompletion();
+        return aludraGUI.getComponentFactory().createButton(FIND_BUTTON_ID).waitingUntilTaskCompletion();
     }
 
     public Button disabledButton() {
-        return new Button(aludraGUI, DISABLED_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(DISABLED_BUTTON_ID);
     }
 
     public Button hiddenButton() {
-        return new Button(aludraGUI, HIDDEN_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(HIDDEN_BUTTON_ID);
     }
 
     public Button hiddenDivButton() {
-        return new Button(aludraGUI, HIDDEN_DIV_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(HIDDEN_DIV_BUTTON_ID);
     }
 
     public Button notExistingButton() {
-        return new Button(aludraGUI, NOT_EXISTING_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(NOT_EXISTING_BUTTON_ID);
     }
 
     public Checkbox firstCheckBox() {
-        return new Checkbox(aludraGUI, FIRST_CHECKBOX_ID);
+        return aludraGUI.getComponentFactory().createCheckbox(FIRST_CHECKBOX_ID);
     }
 
     public Checkbox secondCheckBox() {
-        return new Checkbox(aludraGUI, SECOND_CHECKBOX_ID);
+        return aludraGUI.getComponentFactory().createCheckbox(SECOND_CHECKBOX_ID);
     }
 
     public Checkbox disabledCheckBox() {
-        return new Checkbox(aludraGUI, DISABLED_CHECKBOX_ID);
+        return aludraGUI.getComponentFactory().createCheckbox(DISABLED_CHECKBOX_ID);
     }
 
     public RadioButton andRadioButton() {
-        return new RadioButton(aludraGUI, RADIO_BUTTON_AND);
+        return aludraGUI.getComponentFactory().createRadioButton(RADIO_BUTTON_AND);
     }
 
     public RadioButton orRadioButton() {
-        return new RadioButton(aludraGUI, RADIO_BUTTON_OR);
+        return aludraGUI.getComponentFactory().createRadioButton(RADIO_BUTTON_OR);
     }
 
     public Link testLink() {
-        return new Link(aludraGUI, TEST_LINK_ID);
+        return aludraGUI.getComponentFactory().createLink(TEST_LINK_ID);
     }
 
     public Label image() {
-        return new Label(aludraGUI, IMAGE_ID);
+        return aludraGUI.getComponentFactory().createLabel(IMAGE_ID);
     }
 
     public Button imageButton() {
-        return new Button(aludraGUI, IMAGE_BUTTON_ID);
+        return aludraGUI.getComponentFactory().createButton(IMAGE_BUTTON_ID);
     }
 
     public Label label() {
-        return new Label(aludraGUI, LABEL_ID);
+        return aludraGUI.getComponentFactory().createLabel(LABEL_ID);
     }
 
     public FileField fileField() {
-        return new FileField(aludraGUI, FILE_FIELD_ID);
+        return aludraGUI.getComponentFactory().createFileField(FILE_FIELD_ID);
     }
 
     public Button fileSubmitButton() {
-        return new Button(aludraGUI, SUBMIT_FILE_ID);
+        return aludraGUI.getComponentFactory().createButton(SUBMIT_FILE_ID);
     }
 
     public Label fileNameLabel() {
-        return new Label(aludraGUI, FILE_NAME_ID);
+        return aludraGUI.getComponentFactory().createLabel(FILE_NAME_ID);
     }
 
     public Label fileContentLabel() {
-        return new Label(aludraGUI, FILE_CONTENT_ID);
+        return aludraGUI.getComponentFactory().createLabel(FILE_CONTENT_ID);
     }
 
 }

--- a/src/test/java/org/test/testclasses/page/InvalidPageUtility.java
+++ b/src/test/java/org/test/testclasses/page/InvalidPageUtility.java
@@ -15,7 +15,7 @@
  */
 package org.test.testclasses.page;
 
-import org.aludratest.service.gui.component.Button;
+import org.aludratest.service.gui.AludraGUI;
 import org.aludratest.service.gui.web.page.PageUtility;
 
 public class InvalidPageUtility extends PageUtility {
@@ -29,9 +29,9 @@ public class InvalidPageUtility extends PageUtility {
     }
 
     public static String validPublicMethod() {
-        // but an invalid construction of a button
-        new Button(null, null);
-
+        // but invalid use of GUIComponentFactory
+        AludraGUI gui = null;
+        gui.getComponentFactory().createButton(null);
         return null;
     }
 

--- a/src/test/java/org/test/testclasses/testcase/InvalidNoTestCaseClass.java
+++ b/src/test/java/org/test/testclasses/testcase/InvalidNoTestCaseClass.java
@@ -33,7 +33,8 @@ public class InvalidNoTestCaseClass {
         // cause some bad imports
         Date dt = new Date(1);
         UIMap uiMap = new ConstructingUIMap(null);
-        GUIComponent component = new Button(null, null);
+        GUIComponent component = null;
+        Button button = null;
 
         Page pg = new InvalidPage();
     }

--- a/src/test/java/org/test/testclasses/testcase/InvalidTestCaseClass.java
+++ b/src/test/java/org/test/testclasses/testcase/InvalidTestCaseClass.java
@@ -34,7 +34,8 @@ public class InvalidTestCaseClass extends AludraTestCase {
         // cause some bad imports
         Date dt = new Date(1);
         UIMap uiMap = new ConstructingUIMap(null);
-        GUIComponent component = new Button(null, null);
+        GUIComponent component = null;
+        Button button = null;
 
         Page pg = new InvalidPage();
     }

--- a/src/test/java/org/test/testclasses/uimap/ConstructingUIMap.java
+++ b/src/test/java/org/test/testclasses/uimap/ConstructingUIMap.java
@@ -31,7 +31,7 @@ public class ConstructingUIMap extends UIMap {
     public Button giveMeAButton() {
         ValidUIMapHelper.class.getName();
         ValidUIMapUtility.class.getName();
-        return new Button(aludraGUI, new XPathLocator("/"));
+        return aludraGUI.getComponentFactory().createButton(new XPathLocator("/"));
     }
 
 }

--- a/src/test/resources/config/seleniumWrapper.properties
+++ b/src/test/resources/config/seleniumWrapper.properties
@@ -3,9 +3,10 @@
 driver = CHROME
 use.remotedriver = true
 
+# Selenium 1
 #browser = *iexplore
-#browser = *firefox
-browser = *googlechrome
+browser = *firefox
+#browser = *googlechrome
 browser.log.level = error
 selenium.port = 4444
 


### PR DESCRIPTION
This change replaces the pattern of clients having to construct GUI component objects directly (e.g. `new Button(aludraGUI, myLocator)`) to a factory based way:

`aludraGUI.getComponentFactory().createButton(myLocator);`

This gives AludraTest full control over the object lifecycle and allows for Plexus based Dependency Injection in the component classes.

All client code must be updated to replace the object instantiations with the factory method calls as shown above.