### PR TITLE
Defines and implements waitForAjaxOperationEnd() for Web GUIs

### DIFF
--- a/src/main/java/org/aludratest/service/gui/web/WebGUIInteraction.java
+++ b/src/main/java/org/aludratest/service/gui/web/WebGUIInteraction.java
@@ -96,4 +96,15 @@ public interface WebGUIInteraction extends GUIInteraction {
     String clickForDownload(@ElementType String elementType, @ElementName String elementName,
             @TechnicalLocator GUIElementLocator locator, @TechnicalArgument int taskCompletionTimeout);
 
+    /** Waits for an AJAX operation to be finished. This is usually done with some JavaScript querying a variable of a known
+     * JavaScript framework (e.g. jQuery). <br>
+     * The framework may or may not be supported by the web GUI implementation. If it is not supported, an AutomationException is
+     * thrown. <br>
+     * If the maximum waiting time is reached without the Ajax operation being finished, a PerformanceException is thrown.
+     * 
+     * @param frameworkName Name of the JavaScript framework to check, e.g. "jquery". Implementations should convert this
+     *            parameter to lowercase before checking it, so case does not matter for the caller.
+     * @param maxWaitTime Maximum time, in milliseconds, to wait for the AJAX operation to be finished. */
+    void waitForAjaxOperationEnd(@TechnicalArgument String frameworkName, @TechnicalArgument int maxWaitTime);
+
 }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/JQueryAjaxIdleCondition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/JQueryAjaxIdleCondition.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.selenium1;
+
+import org.aludratest.service.gui.web.selenium.ConditionCheck;
+
+public class JQueryAjaxIdleCondition implements ConditionCheck {
+
+    private SeleniumFacade selenium;
+
+    public JQueryAjaxIdleCondition(SeleniumFacade selenium) {
+        this.selenium = selenium;
+    }
+
+    @Override
+    public boolean eval() {
+        try {
+            return selenium.isJavaScriptExpressionTrue("jQuery.active == 0 || jQuery.ajax.active == 0");
+        }
+        catch (Exception e) {
+            // JS error -> treat as "idle"
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/Selenium1Interaction.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/Selenium1Interaction.java
@@ -248,6 +248,11 @@ public class Selenium1Interaction extends AbstractSeleniumAction implements WebG
     }
 
     @Override
+    public void waitForAjaxOperationEnd(String frameworkName, int maxWaitTime) {
+        wrapper.waitForAjaxOperationEnd(frameworkName, maxWaitTime);
+    }
+
+    @Override
     public void addCustomHttpHeaderCommand(String key, String value) {
         wrapper.addCustomRequestHeader(key, value);
     }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumFacade.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumFacade.java
@@ -401,6 +401,10 @@ public class SeleniumFacade {
         }
     }
 
+    boolean isJavaScriptExpressionTrue(String script) {
+        return "true".equals(selenium.getEval(script));
+    }
+
     /**
      * @param locator
      *            {@link Locator} of the GUI element to examine

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumWrapper.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium1/SeleniumWrapper.java
@@ -15,6 +15,8 @@
  */
 package org.aludratest.service.gui.web.selenium.selenium1;
 
+import java.util.Locale;
+
 import org.aludratest.exception.AutomationException;
 import org.aludratest.exception.FunctionalFailure;
 import org.aludratest.exception.PerformanceFailure;
@@ -37,6 +39,7 @@ import org.aludratest.testcase.event.attachment.Attachment;
 import org.aludratest.testcase.event.attachment.BinaryAttachment;
 import org.aludratest.testcase.event.attachment.StringAttachment;
 import org.apache.commons.codec.binary.Base64;
+import org.openqa.selenium.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -873,6 +876,22 @@ public class SeleniumWrapper {
         }
         if (!windowIsGone) {
             throw new PerformanceFailure("Window not closed within timeout");
+        }
+    }
+
+    public void waitForAjaxOperationEnd(String frameworkName, int maxWaitTime) {
+        frameworkName = frameworkName.toLowerCase(Locale.US);
+        if ("jquery".equals(frameworkName)) {
+            try {
+                retryUntilTrueOrTimeout(new org.aludratest.service.gui.web.selenium.selenium1.JQueryAjaxIdleCondition(selenium),
+                        maxWaitTime);
+            }
+            catch (TimeoutException e) {
+                throw new PerformanceFailure("AJAX operation was not finished within timeout");
+            }
+        }
+        else {
+            throw new AutomationException("Unsupported JavaScript framework for AJAX check: " + frameworkName);
         }
     }
 

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Interaction.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Interaction.java
@@ -242,6 +242,11 @@ public class Selenium2Interaction extends AbstractSelenium2Action implements Web
         wrapper.waitForWindowToBeClosed(locator, taskCompletionTimeout);
     }
 
+    @Override
+    public void waitForAjaxOperationEnd(String frameworkName, int maxWaitTime) {
+        wrapper.waitForAjaxOperationEnd(frameworkName, maxWaitTime);
+    }
+
     // special features --------------------------------------------------------
 
     @Override

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/AbstractAjaxIdleCondition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/AbstractAjaxIdleCondition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.selenium2.condition;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+
+public abstract class AbstractAjaxIdleCondition implements ExpectedCondition<Boolean> {
+
+    protected abstract String getBooleanAjaxIdleScript();
+
+    @Override
+    public Boolean apply(WebDriver input) {
+        try {
+            if (input instanceof JavascriptExecutor) {
+                JavascriptExecutor exec = (JavascriptExecutor) input;
+                Object o = exec.executeScript(getBooleanAjaxIdleScript());
+                if (o instanceof Boolean) {
+                    return (Boolean) o;
+                }
+                else if (o instanceof String) {
+                    return "true".equals(o);
+                }
+                else {
+                    // e.g. "undefined"
+                    return Boolean.TRUE;
+                }
+            }
+            else {
+                // no JavaScript executor - expect AJAX not to be run (--> to be idle)
+                return Boolean.TRUE;
+            }
+        }
+        catch (Exception e) {
+            // e.g. framework not present
+            return Boolean.TRUE;
+        }
+    }
+}

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/IceFacesAjaxIdleCondition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/IceFacesAjaxIdleCondition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.selenium2.condition;
+
+/** The IceFaces implementation for checking current AJAX status. <br>
+ * Notice that this is a more complex piece of JavaScript. It registers a callback which listens for AJAX events and adjusts a
+ * counter. For working as expected, this script must be initialized BEFORE the AJAX call to check begins. Recommended is a simple
+ * way:
+ * 
+ * <pre>
+ * // inits the IceFaces monitoring JavaScript
+ * gui.perform().waitForAjaxOperationEnd("icefaces", 10000);
+ * myAjaxButton.click();
+ * // does the real wait
+ * gui.perform().waitForAjaxOperationEnd("icefaces", 10000);
+ * </pre>
+ * 
+ * @author falbrech */
+public class IceFacesAjaxIdleCondition extends AbstractAjaxIdleCondition {
+
+    // as IceFaces does not have something we could check for active AJAX request, we have to hook into AJAX events...
+    private static final String ICE_FACES_AJAX_CHECK_SCRIPT = "if (typeof(ajaxActive124) === 'undefined') "
+            + "{ var ajaxActive124 = 0; jsf.ajax.addOnEvent(function(data) { switch(data.status) { "
+            + "case 'begin': ajaxActive124 += 1; break; case 'success': ajaxActive124 -= 1; break; } }) } "
+            + "return ajaxActive124 == 0;";
+
+    @Override
+    protected String getBooleanAjaxIdleScript() {
+        return ICE_FACES_AJAX_CHECK_SCRIPT;
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/JQueryAjaxIdleCondition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/JQueryAjaxIdleCondition.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.selenium2.condition;
+
+
+public class JQueryAjaxIdleCondition extends AbstractAjaxIdleCondition {
+
+    @Override
+    protected String getBooleanAjaxIdleScript() {
+        return "return jQuery.active == 0 || jQuery.ajax.active == 0";
+    }
+
+}

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/PrimeFacesAjaxIdleCondition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/condition/PrimeFacesAjaxIdleCondition.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.selenium2.condition;
+
+public class PrimeFacesAjaxIdleCondition extends AbstractAjaxIdleCondition {
+
+    @Override
+    protected String getBooleanAjaxIdleScript() {
+        return "return PrimeFaces.ajax.Queue.isEmpty()";
+    }
+
+}


### PR DESCRIPTION
For Selenium 1, only jQuery is supported (but should be no problem to add other frameworks as well).

For Selenium 2, jQuery, PrimeFaces, and IceFaces AJAX requests are supported.