### PR TITLE
Selenium Visibility Fix

### DIFF
--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/LocatorSupport.java
@@ -37,7 +37,6 @@ import org.aludratest.util.ExceptionUtil;
 import org.aludratest.util.retry.RetryService;
 import org.aludratest.util.timeout.TimeoutService;
 import org.openqa.selenium.By;
-import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
@@ -224,10 +223,6 @@ public class LocatorSupport {
             return waitFor(condition, timeOutInMillis, NoSuchElementException.class, StaleElementReferenceException.class);
         }
         catch (TimeoutException e) {
-            // do not hide InvalidSelectorExceptions
-            if (e.getCause() instanceof InvalidSelectorException) {
-                throw new AutomationException("Invalid element selector", e.getCause());
-            }
             throw new AutomationException("Element not found"); // NOSONAR
         }
     }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Condition.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Condition.java
@@ -20,7 +20,6 @@ import org.aludratest.exception.AutomationException;
 import org.aludratest.service.gui.web.WebGUICondition;
 import org.aludratest.service.locator.element.GUIElementLocator;
 import org.aludratest.service.locator.window.WindowLocator;
-import org.openqa.selenium.InvalidSelectorException;
 
 /** Provides the {@link WebGUICondition} feature set using Selenium 2.
  * @author Marcel Malitz
@@ -46,10 +45,6 @@ public class Selenium2Condition extends AbstractSelenium2Action implements WebGU
             return true;
         }
         catch (AutomationException e) {
-            // do not hide invalid selector exceptions
-            if (e.getCause() instanceof InvalidSelectorException) {
-                throw e;
-            }
             // expected exception: "Element not found"
             return false;
         }

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
@@ -923,6 +923,9 @@ public class Selenium2Wrapper {
     }
 
     public void waitForTextValidity(GUIElementLocator locator, Validator<String> validator) {
+        // ensure element is visible (scroll into view)
+        waitUntilVisible(locator, configuration.getTimeout());
+
         waitForValidity(new ValidatingCondition(locator, locatorSupport, validator, "Text") {
             @Override
             protected String getTextToValidate(WebElement element) {
@@ -932,6 +935,9 @@ public class Selenium2Wrapper {
     }
 
     public void waitForValueValidity(GUIElementLocator locator, Validator<String> validator) {
+        // ensure element is visible (scroll into view)
+        waitUntilVisible(locator, configuration.getTimeout());
+
         waitForValidity(new ValidatingCondition(locator, locatorSupport, validator, "Value") {
             @Override
             protected String getTextToValidate(WebElement element) {

--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Wrapper.java
@@ -668,7 +668,7 @@ public class Selenium2Wrapper {
 
     public void focus(GUIElementLocator locator) {
         LOGGER.debug("focus({})", locator);
-        WebElement element = doBeforeDelegate(locator, true, false, true);
+        WebElement element = waitUntilEnabled(locator, configuration.getTimeout());
         executeScript("arguments[0].focus()", element);
     }
 


### PR DESCRIPTION
Assert text element is visible before calling getText() from assertions. Also, revert a recent change which causes delays in test executions.