### PR TITLE
Fix xml encoding

### DIFF
--- a/src/main/java/org/aludratest/content/xml/XmlContent.java
+++ b/src/main/java/org/aludratest/content/xml/XmlContent.java
@@ -95,10 +95,15 @@ public interface XmlContent extends ContentHandler {
 
     /** Uses a FreeMarker template to create an XML document based on the content of a variables map.
      * @param templateUri the URI of the template to apply
+<<<<<<< Updated upstream
      * @param encoding the encoding of the template file
+=======
+     * @param templateEncoding the encoding in which the template file was saved
+     * @param xmlEncoding the encoding to be used in the created XML document
+>>>>>>> Stashed changes
      * @param variables values to provide as template variables
      * @return an XML {@link Document} with the data configured in the variables map */
-    Document createDocument(String templateUri, String encoding, Map<String, Object> variables);
+    Document createDocument(String templateUri, String templateEncoding, String xmlEncoding, Map<String, Object> variables);
 
     /** Checks if two XML documents are equal ignoring elements that match the provided xpath expressions.
      * @param expected the expected document structure

--- a/src/main/java/org/aludratest/content/xml/XmlContent.java
+++ b/src/main/java/org/aludratest/content/xml/XmlContent.java
@@ -96,10 +96,9 @@ public interface XmlContent extends ContentHandler {
     /** Uses a FreeMarker template to create an XML document based on the content of a variables map.
      * @param templateUri the URI of the template to apply
      * @param templateEncoding the encoding in which the template file was saved
-     * @param xmlEncoding the encoding to be used in the created XML document
      * @param variables values to provide as template variables
      * @return an XML {@link Document} with the data configured in the variables map */
-    Document createDocument(String templateUri, String templateEncoding, String xmlEncoding, Map<String, Object> variables);
+    Document createDocument(String templateUri, String templateEncoding, Map<String, Object> variables);
 
     /** Checks if two XML documents are equal ignoring elements that match the provided xpath expressions.
      * @param expected the expected document structure

--- a/src/main/java/org/aludratest/content/xml/XmlContent.java
+++ b/src/main/java/org/aludratest/content/xml/XmlContent.java
@@ -95,12 +95,8 @@ public interface XmlContent extends ContentHandler {
 
     /** Uses a FreeMarker template to create an XML document based on the content of a variables map.
      * @param templateUri the URI of the template to apply
-<<<<<<< Updated upstream
-     * @param encoding the encoding of the template file
-=======
      * @param templateEncoding the encoding in which the template file was saved
      * @param xmlEncoding the encoding to be used in the created XML document
->>>>>>> Stashed changes
      * @param variables values to provide as template variables
      * @return an XML {@link Document} with the data configured in the variables map */
     Document createDocument(String templateUri, String templateEncoding, String xmlEncoding, Map<String, Object> variables);

--- a/src/main/java/org/aludratest/content/xml/impl/XmlContentImpl.java
+++ b/src/main/java/org/aludratest/content/xml/impl/XmlContentImpl.java
@@ -182,13 +182,14 @@ public class XmlContentImpl implements XmlContent {
     // document creation -------------------------------------------------------
 
     @Override
-    public Document createDocument(String templateUri, String encoding, Map<String, Object> variables) {
+    public Document createDocument(String templateUri, String templateEncoding, String xmlEncoding, Map<String, Object> variables) {
         try {
             // prepare generator
             FreeMarkerScriptFactory factory = new FreeMarkerScriptFactory(Locale.ENGLISH);
-            Script script = factory.parseText(IOUtil.getContentOfURI(templateUri));
+            String templateText = IOUtil.getContentOfURI(templateUri, templateEncoding);
+            Script script = factory.parseText(templateText);
             Context context = new DefaultContext(variables);
-            context.set("documentEncoding", "UTF-8");
+            context.set("documentEncoding", xmlEncoding);
             // apply template
             String xmlText = String.valueOf(script.evaluate(context));
             // return result

--- a/src/main/java/org/aludratest/content/xml/impl/XmlContentImpl.java
+++ b/src/main/java/org/aludratest/content/xml/impl/XmlContentImpl.java
@@ -182,14 +182,13 @@ public class XmlContentImpl implements XmlContent {
     // document creation -------------------------------------------------------
 
     @Override
-    public Document createDocument(String templateUri, String templateEncoding, String xmlEncoding, Map<String, Object> variables) {
+    public Document createDocument(String templateUri, String templateEncoding, Map<String, Object> variables) {
         try {
             // prepare generator
             FreeMarkerScriptFactory factory = new FreeMarkerScriptFactory(Locale.ENGLISH);
             String templateText = IOUtil.getContentOfURI(templateUri, templateEncoding);
             Script script = factory.parseText(templateText);
             Context context = new DefaultContext(variables);
-            context.set("documentEncoding", xmlEncoding);
             // apply template
             String xmlText = String.valueOf(script.evaluate(context));
             // return result

--- a/src/main/java/org/aludratest/service/cmdline/impl/ProcessWrapper.java
+++ b/src/main/java/org/aludratest/service/cmdline/impl/ProcessWrapper.java
@@ -76,7 +76,7 @@ public class ProcessWrapper {
         return processId;
     }
 
-    /** @return the command tokes used in construction */
+    /** @return the command tokens used in construction */
     public List<String> getCommand() {
         return builder.command();
     }

--- a/src/test/java/org/aludratest/content/xml/XmlContentImplTest.java
+++ b/src/test/java/org/aludratest/content/xml/XmlContentImplTest.java
@@ -136,7 +136,7 @@ public class XmlContentImplTest {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("attvar", "val");
         variables.put("textvar", "text");
-        Document doc = content.createDocument(FTL_TEMPLATE, Encodings.UTF_8, variables);
+        Document doc = content.createDocument(FTL_TEMPLATE, Encodings.UTF_8, Encodings.UTF_8, variables);
         verifySimpleDocument(doc);
     }
 

--- a/src/test/java/org/aludratest/content/xml/XmlContentImplTest.java
+++ b/src/test/java/org/aludratest/content/xml/XmlContentImplTest.java
@@ -136,7 +136,7 @@ public class XmlContentImplTest {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("attvar", "val");
         variables.put("textvar", "text");
-        Document doc = content.createDocument(FTL_TEMPLATE, Encodings.UTF_8, Encodings.UTF_8, variables);
+        Document doc = content.createDocument(FTL_TEMPLATE, Encodings.UTF_8, variables);
         verifySimpleDocument(doc);
     }
 

--- a/src/test/resources/org/aludratest/content/xml/xml_template.ftl
+++ b/src/test/resources/org/aludratest/content/xml/xml_template.ftl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="${documentEncoding}" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <root att="${attvar}">
   <node>${textvar}</node>
 </root>


### PR DESCRIPTION
Interface change needed for correct handling of file encodings: The createDocument() method now differs between 'templateEncoding' and 'xmlEncoding'