### PR TITLE
Throwing FunctionalFailure when file preexists and overwriting is not…

### DIFF
--- a/src/main/java/org/aludratest/service/file/FileInteraction.java
+++ b/src/main/java/org/aludratest/service/file/FileInteraction.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.util.List;
 
 import org.aludratest.exception.AutomationException;
+import org.aludratest.exception.FunctionalFailure;
 import org.aludratest.service.ElementType;
 import org.aludratest.service.Interaction;
 import org.aludratest.service.TechnicalLocator;
@@ -31,129 +32,129 @@ import org.aludratest.service.TechnicalLocator;
  */
 public interface FileInteraction extends Interaction {
 
-    /** Provides the root folder of the service instance. 
+    /** Provides the root folder of the service instance.
      *  @return the root folder of the {@link FileService}. */
     String getRootFolder();
 
-    /** Lists all child elements of the given folder. 
-     *  @param filePath the path of the file of which to get children 
+    /** Lists all child elements of the given folder.
+     *  @param filePath the path of the file of which to get children
      *  @return a {@link List} of the child objects of the given file
      */
     List<String> getChildren(@TechnicalLocator String filePath);
 
-    /** Lists all child elements of the given folder which match the given regular expression. 
-     *  @param filePath the path of the file of which to get the children 
-     *  @param filterRegex 
+    /** Lists all child elements of the given folder which match the given regular expression.
+     *  @param filePath the path of the file of which to get the children
+     *  @param filterRegex
      *  @return a {@link List} of the child objects of the given file
      */
     List<String> getChildren(@TechnicalLocator String filePath, String filterRegex);
 
-    /** Lists all child elements of the given folder which match the filter. 
+    /** Lists all child elements of the given folder which match the filter.
      *  @param filePath the path of the file of which to get the children
-     *  @param filter 
+     *  @param filter
      *  @return a {@link List} of the child objects of the given file
      */
     List<String> getChildren(@TechnicalLocator String filePath, FileFilter filter);
 
-    /** Creates a directory. 
-     *  @param directoryPath the path of the directory to create 
+    /** Creates a directory.
+     *  @param directoryPath the path of the directory to create
      */
     void createDirectory(@TechnicalLocator String directoryPath);
 
-    /** Renames or moves a file or folder. 
-     *  @param fromPath the file/folder to rename/move
-     *  @param toPath the new name/location of the file/folder
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+    /** Renames or moves a file or folder.
+     * @param fromPath the file/folder to rename/move
+     * @param toPath the new name/location of the file/folder
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean move(@TechnicalLocator String fromPath, String toPath, boolean overwrite);
 
     /** Copies a file or folder.
-     *  @param fromPath the file/folder to copy
-     *  @param toPath the name/location of the copy
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+     * @param fromPath the file/folder to copy
+     * @param toPath the name/location of the copy
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean copy(@TechnicalLocator String fromPath, String toPath, boolean overwrite);
 
-    /** Deletes a file or folder. 
+    /** Deletes a file or folder.
      *  @param filePath the path of the file to delete
      */
     void delete(@TechnicalLocator String filePath);
 
     /** Creates a text file with the provided content.
-     *  @param filePath the path of the file to save
-     *  @param text the text to save as file content
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+     * @param filePath the path of the file to save
+     * @param text the text to save as file content
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean writeTextFile(@TechnicalLocator String filePath, String text, boolean overwrite);
 
     /** Creates a text file and writes to it all content provided by the source Reader.
-     *  @param filePath the path of the file to save
-     *  @param source a {@link Reader} which provides the file content
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+     * @param filePath the path of the file to save
+     * @param source a {@link Reader} which provides the file content
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean writeTextFile(@TechnicalLocator String filePath, Reader source, boolean overwrite);
 
     /** Creates a binary file with the provided content.
-     *  @param filePath the path of the file to save
-     *  @param bytes the file content to write
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+     * @param filePath the path of the file to save
+     * @param bytes the file content to write
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean writeBinaryFile(@TechnicalLocator String filePath, byte[] bytes, boolean overwrite);
 
     /** Creates a binary file and writes to it all content provided by the source {@link InputStream}.
-     *  @param filePath the path of the file to save
-     *  @param source an {@link InputStream} which provides the content to write to the file
-     *  @param overwrite flag which indicates if an existing file may be overwritten by the operation
-     *  @return true if a formerly existing file was overwritten. 
-     *  @throws org.aludratest.service.file.exception.FilePresentException if a file was already present and overwriting was disabled. */
+     * @param filePath the path of the file to save
+     * @param source an {@link InputStream} which provides the content to write to the file
+     * @param overwrite flag which indicates if an existing file may be overwritten by the operation
+     * @return true if a formerly existing file was overwritten.
+     * @throws FunctionalFailure if a file was already present and overwriting was disabled. */
     boolean writeBinaryFile(@TechnicalLocator String filePath, InputStream source, boolean overwrite);
 
-    /** Reads a text file and provides its content as String. 
-     *  @param filePath the path of the file to read 
+    /** Reads a text file and provides its content as String.
+     *  @param filePath the path of the file to read
      *  @return the content of the file */
     String readTextFile(@TechnicalLocator String filePath);
 
-    /** Creates a {@link Reader} for accessing the content of a text file. 
-     *  @param filePath the path of the file to read 
+    /** Creates a {@link Reader} for accessing the content of a text file.
+     *  @param filePath the path of the file to read
      *  @return a reader for the text file */
     BufferedReader getReaderForTextFile(@TechnicalLocator String filePath);
 
-    /** Reads a binary file and provides its content as an array of bytes. 
-     *  @param filePath the path of the file to read 
+    /** Reads a binary file and provides its content as an array of bytes.
+     *  @param filePath the path of the file to read
      *  @return the file content as byte array */
     byte[] readBinaryFile(@TechnicalLocator String filePath);
 
-    /** Creates an {@link InputStream} for accessing the content of a file. 
-     *  @param filePath the path of the file for which to get an input stream 
+    /** Creates an {@link InputStream} for accessing the content of a file.
+     *  @param filePath the path of the file for which to get an input stream
      *  @return an {@link InputStream} for accessing the file */
     InputStream getInputStreamForFile(@TechnicalLocator String filePath);
 
     /** Polls the file system for a given file until it is found or a timeout is exceeded.
-     *  Timeout and the maximum number of polls are retrieved from the 
-     *  {@link org.aludratest.service.file.impl.FileServiceConfiguration}. 
-     *  @param elementType 
-     *  @param filePath the path of the file for which to wait 
+     *  Timeout and the maximum number of polls are retrieved from the
+     *  {@link org.aludratest.service.file.impl.FileServiceConfiguration}.
+     *  @param elementType
+     *  @param filePath the path of the file for which to wait
      *  @throws AutomationException if the file was not found within the timeout */
     void waitUntilExists(
-            @ElementType String elementType, 
+            @ElementType String elementType,
             @TechnicalLocator String filePath);
 
     /** Polls the file system for a given file until it has disappeared or a timeout is exceeded.
-     *  Timeout and the maximum number of polls are retrieved from the 
-     *  {@link org.aludratest.service.file.impl.FileServiceConfiguration}. 
-     *  @param filePath the path of the file for which to wait until absence 
+     *  Timeout and the maximum number of polls are retrieved from the
+     *  {@link org.aludratest.service.file.impl.FileServiceConfiguration}.
+     *  @param filePath the path of the file for which to wait until absence
      *  @throws AutomationException if the file was not found within the timeout */
     void waitUntilNotExists(@TechnicalLocator String filePath);
 
     /** Polls the given directory until the filter finds a match or a timeout is exceeded.
-     *  Timeout and the maximum number of polls are retrieved from the 
+     *  Timeout and the maximum number of polls are retrieved from the
      *  {@link org.aludratest.service.file.impl.FileServiceConfiguration}.
-     *  @param parentPath the path of the directory in which to search for the file 
+     *  @param parentPath the path of the directory in which to search for the file
      *  @param filter a filter object that decides which file is to be accepted
      *  @return the file path of the first file that was accepted by the filter
      *  @throws AutomationException if the file was not found within the timeout */

--- a/src/main/java/org/aludratest/service/file/impl/FileActionImpl.java
+++ b/src/main/java/org/aludratest/service/file/impl/FileActionImpl.java
@@ -50,7 +50,6 @@ import org.aludratest.util.poll.PolledTask;
 import org.apache.commons.vfs2.AllFileSelector;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelector;
-import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 import org.databene.commons.IOUtil;
 import org.databene.commons.Validator;
@@ -127,7 +126,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
                 LOGGER.debug("No children found for filter {}", filter);
             }
             return filePaths;
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error retrivieving child objects", e);
         }
     }
@@ -140,7 +140,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
         try {
             getFileObject(filePath).createFolder();
             LOGGER.debug("Created directory {}", filePath);
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Directory creation failed", e);
         }
     }
@@ -156,14 +157,15 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
         assertWritingPermitted("move()");
         File.verifyFilePath(fromPath);
         File.verifyFilePath(toPath);
-        FileObject target = getFileObject(toPath);
-        boolean existedBefore = checkWritable(target, overwrite);
         try {
+            FileObject target = getFileObject(toPath);
+            boolean existedBefore = checkWritable(target, overwrite);
             getOrCreateDirectory(target.getParent());
             getFileObject(fromPath).moveTo(target);
             LOGGER.debug("Moved {} to {}", fromPath, toPath);
             return existedBefore;
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error moving file" + fromPath + " -> " + toPath, e);
         }
     }
@@ -179,15 +181,16 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
         assertWritingPermitted("copy()");
         File.verifyFilePath(fromPath);
         File.verifyFilePath(toPath);
-        FileObject target = getFileObject(toPath);
-        boolean existedBefore = checkWritable(target, overwrite);
         try {
+            FileObject target = getFileObject(toPath);
+            boolean existedBefore = checkWritable(target, overwrite);
             FileObject source = getFileObject(fromPath);
             FileSelector sourceSelector = new FilePathSelector(source.getName().getPath());
             target.copyFrom(source, sourceSelector);
             LOGGER.debug("Copied {} to {}", fromPath, toPath);
             return existedBefore;
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error copying file " + fromPath + " -> " + toPath, e);
         }
     }
@@ -200,7 +203,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
         try {
             getFileObject(filePath).delete(new AllFileSelector());
             LOGGER.debug("Deleted {}", filePath);
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error deleting file", e);
         }
     }
@@ -250,7 +254,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             return existedBefore;
         } catch (UnsupportedEncodingException e) {
             throw new TechnicalException("Unsupported Encoding:" + encoding, e);
-        } catch (Exception e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error writing text file", e);
         } finally {
             IOUtil.close(writer);
@@ -289,7 +294,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             IOUtil.transfer(source, out);
             LOGGER.debug("Wrote binary file {}", filePath);
             return existedBefore;
-        } catch (Exception e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error writing text file", e);
         } finally {
             IOUtil.close(out);
@@ -370,7 +376,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
         try {
             LOGGER.debug("Providing InputStream for binary file: {}", filePath);
             return file.getContent().getInputStream();
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error opening InputStream", e);
         }
     }
@@ -456,7 +463,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             boolean result = file.exists();
             LOGGER.debug("File '{}' {}", filePath, (result ? "exists" : "does not exist"));
             return result;
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error checking file presence", e);
         }
     }
@@ -491,7 +499,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             boolean result = getFileObject(filePath).getType() == FileType.FOLDER;
             LOGGER.debug("{} is {}", filePath, (result ? "a folder" : "not a folder"));
             return result;
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error accessing file or folder", e);
         }
     }
@@ -528,7 +537,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             } else {
                 return false;
             }
-        } catch (FileSystemException e) {
+        }
+        catch (IOException e) {
             throw new TechnicalException("Error checking file", e);
         }
     }
@@ -539,7 +549,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
             try {
                 getOrCreateDirectory(directory.getParent());
                 directory.createFolder();
-            } catch (FileSystemException e) {
+            }
+            catch (IOException e) {
                 throw new TechnicalException("Error creating directory", e);
             }
         }
@@ -582,7 +593,8 @@ public final class FileActionImpl implements FileInteraction, FileVerification, 
                     LOGGER.debug("File not found: {}", filePath);
                     return (awaitExistence ? null : filePath);
                 }
-            } catch (FileSystemException e) {
+            }
+            catch (IOException e) {
                 throw new TechnicalException("Error checking presence of file ", e);
             }
         }

--- a/src/test/java/org/aludratest/service/file/LocalFileServiceTest.java
+++ b/src/test/java/org/aludratest/service/file/LocalFileServiceTest.java
@@ -269,6 +269,12 @@ public class LocalFileServiceTest extends AbstractLocalFileServiceTest {
         assertArrayEquals("binary".getBytes(), bytes);
     }
 
+    @Test(expected = FunctionalFailure.class)
+    public void testWriteBinaryFile_preexisting() throws IOException {
+        service.perform().writeBinaryFile("out2.dat", "binary".getBytes(), true);
+        service.perform().writeBinaryFile("out2.dat", "binary".getBytes(), false);
+    }
+
     @Test(expected = AutomationException.class)
     public void testWriteBinaryFile_noPath() {
         service.perform().writeBinaryFile("", "binary".getBytes(), true);


### PR DESCRIPTION
… allowed. This now happens uniformly in all related methods, fixing a bug that caused a TechnicalException in some methods.