### PR TITLE
Add "timetravel" functionality for date-based script calculations

### DIFF
--- a/src/main/java/org/aludratest/config/AludraTestConfig.java
+++ b/src/main/java/org/aludratest/config/AludraTestConfig.java
@@ -18,7 +18,7 @@ package org.aludratest.config;
 /** Provides the central configuration of AludraTest. <br>
  * If you need access to an instance of this interface, the preferred way is to ask your context object for a
  * <code>newComponentInstance()</code> using this Interface class as the key.
- * 
+ *
  * @author Volker Bergmann
  * @author falbrech */
 @InternalComponent(singleton = true)
@@ -33,7 +33,8 @@ package org.aludratest.config;
     @ConfigProperty(name = AludraTestConfig.NUMERIC_TOLERANCE_PROP, type = double.class, description = "The maximum allowed difference of a current and an expected value. This is for handling rounding issues when dealing with double precision values.", defaultValue = " 0.00000001"),
     @ConfigProperty(name = AludraTestConfig.DEBUG_ON_FRAMEWORK_EXCEPTION_PROP, type = boolean.class, description = "If set to true, debug attachments (e.g. screenshots) will be created also on framework (blue) errors.", defaultValue = "false"),
     @ConfigProperty(name = AludraTestConfig.RUNNER_TREE_SORTER_PROP, type = String.class, description = "A simple or fully qualified name of a Runner Tree Sorter class to use. Default sorter is the Alphabetic sorter. This sorting only applies for filter / grouping execution mode (not for suite-based execution mode).", defaultValue = "Alphabetic"),
-    @ConfigProperty(name = AludraTestConfig.ATTACHMENTS_AS_FILE_PROP, type = boolean.class, description = "If set to true, test step attachments are buffered on the file system as temporary files (using File.createTempFile()). This helps reducing memory usage when running many test cases. Default is false.", defaultValue = "false") })
+    @ConfigProperty(name = AludraTestConfig.ATTACHMENTS_AS_FILE_PROP, type = boolean.class, description = "If set to true, test step attachments are buffered on the file system as temporary files (using File.createTempFile()). This helps reducing memory usage when running many test cases. Default is false.", defaultValue = "false"),
+    @ConfigProperty(name = AludraTestConfig.SECONDS_OFFSET_PROP, type = int.class, description = "Amount of seconds to add to script calculations when evaluating test data. Use negative amount to subtract. Can be used for 'time travel' features of application under test.") })
 public interface AludraTestConfig extends Configurable {
 
     /** Configuration property name. */
@@ -69,6 +70,9 @@ public interface AludraTestConfig extends Configurable {
     /** Configuration property name. */
     public static final String ATTACHMENTS_AS_FILE_PROP = "attachments.filebuffer";
 
+    /** Configuration property name. */
+    public static final String SECONDS_OFFSET_PROP = "script.seconds.offset";
+
     // interface ---------------------------------------------------------------
 
     /** @return The version of AludraTest, e.g. <code>2.7.0-17</code>. */
@@ -98,25 +102,31 @@ public interface AludraTestConfig extends Configurable {
     public boolean isIgnoreEnabled();
 
     /** Returns the numeric tolerance to use for double precision based operations.
-     * 
+     *
      * @return The numeric tolerance to use for double precision based operations. */
     public double getNumericTolerance();
 
     /** Returns if debug attachments shall be created when a Framework Exception occurs.
-     * 
+     *
      * @return <code>true</code> if to include debug attachments on Framework Exceptions. */
     public boolean isDebugAttachmentsOnFrameworkException();
 
     /** Returns the simple or fully qualified name of a Runner Tree Sorter to use. Simple names should be looked up in package
      * <code>org.aludratest.scheduler.sort</code>.
-     * 
+     *
      * @return The simple or fully qualified name of a Runner Tree Sorter to use. */
     public String getRunnerTreeSorterName();
 
     /** Returns <code>true</code> if test step attachments shall be buffered on the file system as temporary files, to reduce
      * memory usage when running many test cases.
-     * 
+     *
      * @return <code>true</code> to buffer test step attachments on file system, <code>false</code> otherwise. */
     public boolean isAttachmentsFileBuffer();
+
+    /** Returns the amount of seconds to add to test data script results (when they evaluate to a <code>Date</code> value). This
+     * can be used for "time travel" features of the application under test.
+     *
+     * @return The amount of seconds to add to test data script results. Can be zero or negative. */
+    public int getScriptSecondsOffset();
 
 }

--- a/src/main/java/org/aludratest/config/impl/AludraTestConfigImpl.java
+++ b/src/main/java/org/aludratest/config/impl/AludraTestConfigImpl.java
@@ -29,7 +29,7 @@ import org.databene.commons.version.VersionInfo;
 
 /** Default implementation of the AludraTestConfig interface. Provides an accessor to the instance, if any, but this should only be
  * used by AludraTest internal components.
- * 
+ *
  * @author Volker Bergmann
  * @author falbrech */
 @Implementation({ AludraTestConfig.class })
@@ -70,6 +70,8 @@ public class AludraTestConfigImpl implements AludraTestConfig, Configurable {
     private String sorterName;
 
     private boolean attachmentsFileBuffer;
+
+    private int scriptSecondsOffset;
 
 
     // constructor -------------------------------------------------------------
@@ -160,6 +162,11 @@ public class AludraTestConfigImpl implements AludraTestConfig, Configurable {
         return attachmentsFileBuffer;
     }
 
+    @Override
+    public int getScriptSecondsOffset() {
+        return scriptSecondsOffset;
+    }
+
     // private helper methods --------------------------------------------------
 
     private void readAludraTestVersion() {
@@ -206,6 +213,8 @@ public class AludraTestConfigImpl implements AludraTestConfig, Configurable {
         this.sorterName = config.getStringValue(RUNNER_TREE_SORTER_PROP, Alphabetic.class.getSimpleName());
 
         this.attachmentsFileBuffer = config.getBooleanValue(ATTACHMENTS_AS_FILE_PROP, false);
+
+        this.scriptSecondsOffset = config.getIntValue(SECONDS_OFFSET_PROP, 0);
     }
 
 }

--- a/src/main/java/org/aludratest/testcase/data/impl/xml/XmlBasedTestDataProvider.java
+++ b/src/main/java/org/aludratest/testcase/data/impl/xml/XmlBasedTestDataProvider.java
@@ -69,7 +69,7 @@ import org.mozilla.javascript.Undefined;
  * <li>Relative to <i>xlsRootPath</i>
  * </ol>
  * xlsRootPath value is configured in aludratest.properties.
- * 
+ *
  * @author falbrech */
 public class XmlBasedTestDataProvider implements TestDataProvider {
 
@@ -472,7 +472,7 @@ public class XmlBasedTestDataProvider implements TestDataProvider {
     }
 
     /** Evaluates the given data script, applying the given format pattern and locale, if specified.
-     * 
+     *
      * @param script Script to evaluate, e.g. <code>addDaysToNow(5)</code>
      * @param formatPattern Format pattern to apply. Can be a format accepted by <code>SimpleDateFormat</code> or
      *            <code>DecimalFormat</code>, depending on type of expression. If not specified, a type-specific default format is
@@ -506,6 +506,11 @@ public class XmlBasedTestDataProvider implements TestDataProvider {
                     return null;
                 }
                 result = toJavaObject(result);
+
+                // apply time travel
+                if (result instanceof Date && aludraConfig.getScriptSecondsOffset() != 0) {
+                    result = new Date(((Date) result).getTime() + aludraConfig.getScriptSecondsOffset());
+                }
 
                 // apply patterns, if required
                 result = format(result, formatPattern, locale);

--- a/src/main/java/org/aludratest/testcase/data/impl/xml/XmlBasedTestDataProvider.java
+++ b/src/main/java/org/aludratest/testcase/data/impl/xml/XmlBasedTestDataProvider.java
@@ -509,7 +509,7 @@ public class XmlBasedTestDataProvider implements TestDataProvider {
 
                 // apply time travel
                 if (result instanceof Date && aludraConfig.getScriptSecondsOffset() != 0) {
-                    result = new Date(((Date) result).getTime() + aludraConfig.getScriptSecondsOffset());
+                    result = new Date(((Date) result).getTime() + aludraConfig.getScriptSecondsOffset() * 1000);
                 }
 
                 // apply patterns, if required

--- a/src/test/java/org/aludratest/config/impl/AludraTestingTestConfigImpl.java
+++ b/src/test/java/org/aludratest/config/impl/AludraTestingTestConfigImpl.java
@@ -32,6 +32,8 @@ public class AludraTestingTestConfigImpl extends AludraTestConfigImpl {
 
     private String sorterName;
 
+    private Integer scriptSecondsOffset;
+
     public AludraTestingTestConfigImpl() {
         super();
         testInstance = this;
@@ -47,6 +49,10 @@ public class AludraTestingTestConfigImpl extends AludraTestConfigImpl {
 
     public void setStopTestCaseOnOtherException(Boolean stopTestCaseOnOtherException) {
         this.stopTestCaseOnOtherException = stopTestCaseOnOtherException;
+    }
+
+    public void setScriptSecondsOffset(Integer scriptSecondsOffset) {
+        this.scriptSecondsOffset = scriptSecondsOffset;
     }
 
     @Override
@@ -111,6 +117,14 @@ public class AludraTestingTestConfigImpl extends AludraTestConfigImpl {
             return sorterName;
         }
         return super.getRunnerTreeSorterName();
+    }
+
+    @Override
+    public int getScriptSecondsOffset() {
+        if (scriptSecondsOffset != null) {
+            return scriptSecondsOffset.intValue();
+        }
+        return super.getScriptSecondsOffset();
     }
 
 }

--- a/src/test/java/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest.java
+++ b/src/test/java/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest.java
@@ -169,7 +169,7 @@ public class XmlBasedTestDataProviderTest {
         XmlBasedTestDataProvider provider = createProvider(config);
         List<TestCaseData> testData = provider
                 .getTestDataSets(XmlBasedTestDataProviderTest.class.getDeclaredMethod("testMethodTimetravel", StringData.class));
-        assertEquals("2015-03-07", ((StringData) testData.get(0).getData()[0]).getValue());
+        assertEquals("2015-03-07 23:58", ((StringData) testData.get(0).getData()[0]).getValue());
     }
 
     @Test

--- a/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
+++ b/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<testdata xmlns="http://aludratest.org/testdata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://aludratest.org/testdata http://aludratest.github.io/aludratest/schema/draft/testdata.xsd" 
+	version="1.0">
+    <metadata>
+        <segments>
+        <segment name="stringObject"
+        	dataClassName="org.aludratest.util.data.StringData">
+        <fields>
+        	<field name="value" fieldType="DATE" formatterPattern="yyyy-MM-dd"/>
+        </fields>
+        </segment>
+        </segments>
+    </metadata>
+
+    <configurations>
+    <configuration name="config1">
+    	<segments>
+    		<segment name="stringObject">
+    			<fieldValues>
+    				<fieldValue name="value" script="true">
+    					<value>new Date(&quot;8 Mar 2015&quot;)</value>
+    				</fieldValue>
+    			</fieldValues>
+    		</segment>
+    	</segments>
+    </configuration>
+    </configurations>
+</testdata>

--- a/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
+++ b/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
@@ -8,7 +8,7 @@
         <segment name="stringObject"
         	dataClassName="org.aludratest.util.data.StringData">
         <fields>
-        	<field name="value" fieldType="DATE" formatterPattern="yyyy-MM-dd"/>
+        	<field name="value" fieldType="DATE" formatterPattern="yyyy-MM-dd HH:mm"/>
         </fields>
         </segment>
         </segments>
@@ -20,7 +20,7 @@
     		<segment name="stringObject">
     			<fieldValues>
     				<fieldValue name="value" script="true">
-    					<value>new Date(&quot;8 Mar 2015&quot;)</value>
+    					<value>new Date(&quot;8 Mar 2015 23:58:00&quot;)</value>
     				</fieldValue>
     			</fieldValues>
     		</segment>


### PR DESCRIPTION
This allows for moving time-based tests into a timeframe supported by the test bed of the Application Under Test.