### PR TITLE
Enhancement: test naming convention rules

### DIFF
--- a/src/main/java/org/aludratest/codecheck/rule/pmd/AbstractRegexNamingRule.java
+++ b/src/main/java/org/aludratest/codecheck/rule/pmd/AbstractRegexNamingRule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.codecheck.rule.pmd;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.rule.properties.StringProperty;
+
+/** Parent class for PMD rules that match a name against a regular expression.
+ * @author Volker Bergmann */
+public abstract class AbstractRegexNamingRule extends AbstractAludraTestRule {
+
+    private static final String REGEX_PROPERTY_NAME = "regex";
+    private static final String MESSAGE_PROPERTY_NAME = "violationMessage";
+
+    /** The pmd property definition for the regex */
+    public final StringProperty regexProperty;
+
+    /** The pmd property definition for the violation message */
+    public final StringProperty messageProperty;
+
+    /** Default constructor, setting the default regular expression
+     * @param defaultRegex the default regex to use if none is configured explicitly.
+     * @param defaultMessage the default message to use for violation messages if none is configured explicitly. */
+    public AbstractRegexNamingRule(String defaultRegex, String defaultMessage) {
+        this.regexProperty = new StringProperty(REGEX_PROPERTY_NAME, "the regular expression to be matched", defaultRegex, 1f);
+        super.definePropertyDescriptor(this.regexProperty);
+        this.messageProperty = new StringProperty(MESSAGE_PROPERTY_NAME, "the regular expression to be matched", defaultMessage,
+                1f);
+        super.definePropertyDescriptor(this.messageProperty);
+    }
+
+    /** Tells if the provided name matches the configured regular expression.
+     * @param name the name to check
+     * @return true if the name matches the configured regex, otherwise false */
+    protected boolean matches(String name) {
+        Pattern pattern = Pattern.compile(getRegex());
+        return pattern.matcher(name).matches();
+    }
+
+    protected void assertMatch(String name, AbstractNode node, Object data) {
+        if (!matches(name)) {
+            addViolationWithMessage(data, node, getViolationMessage());
+        }
+    }
+
+    protected String getRegex() {
+        return getProperty(regexProperty);
+    }
+
+    protected String getViolationMessage() {
+        return getProperty(messageProperty);
+    }
+
+}

--- a/src/main/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRule.java
+++ b/src/main/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRule.java
@@ -35,10 +35,7 @@ public class TestCaseClassNamingRule extends AbstractRegexNamingRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (isTestCaseClass(node)) {
-            String className = node.getImage();
-            if (!matches(className)) {
-                addViolationWithMessage(data, node, "Test class names should match the regular expression '" + getRegex() + "'");
-            }
+            assertMatch(node.getImage(), node, data);
         }
         return data;
     }

--- a/src/main/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRule.java
+++ b/src/main/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.codecheck.rule.pmd.testcase;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.rule.properties.StringProperty;
+
+import org.aludratest.codecheck.rule.pmd.AbstractAludraTestRule;
+
+/** Requires the names of test case methods to match a regular expression.
+ * @author Volker Bergmann */
+public class TestCaseClassNamingRule extends AbstractAludraTestRule {
+
+    private static final String DEFAULT_REGEX = "[A-Z][A-Za-z0-9]*";
+
+    /** The pmd property definition for the regex */
+    public static final StringProperty REGEX_PROPERTY = new StringProperty("regex", "the regular expression to be matched",
+            DEFAULT_REGEX, 1f);
+
+    /** Default constructor, setting the default regular expression */
+    public TestCaseClassNamingRule() {
+        super.definePropertyDescriptor(REGEX_PROPERTY);
+    }
+
+    @Override
+    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+        if (isTestCaseClass(node)) {
+            String regex = getProperty(REGEX_PROPERTY);
+            Pattern pattern = Pattern.compile(regex);
+            String className = node.getImage();
+            if (!pattern.matcher(className).matches()) {
+                addViolationWithMessage(data, node, "Test class names should match the regular expression '" + regex + "'");
+            }
+        }
+        return data;
+    }
+
+}

--- a/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRuleTest.java
+++ b/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRuleTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.codecheck.rule.pmd.testcase;
+
+import net.sourceforge.pmd.Report;
+
+import org.aludratest.codecheck.rule.pmd.AbstractPmdTestCase;
+import org.junit.Test;
+import org.test.testclasses.testcase.InvalidTestCaseClass;
+import org.test.testclasses.testcase.ValidTestCaseClass;
+
+@SuppressWarnings("javadoc")
+public class TestCaseClassNamingRuleTest extends AbstractPmdTestCase {
+
+    @Test
+    public void testInvalidClass() {
+        TestCaseClassNamingRule rule = new TestCaseClassNamingRule();
+        rule.setProperty(TestCaseClassNamingRule.REGEX_PROPERTY, "ValidTestCaseClass");
+        Report report = runPmdTest(InvalidTestCaseClass.class, rule);
+        assertReportViolations(report, 1);
+    }
+
+    @Test
+    public void testValidClass() {
+        TestCaseClassNamingRule rule = new TestCaseClassNamingRule();
+        rule.setProperty(TestCaseClassNamingRule.REGEX_PROPERTY, "ValidTestCaseClass");
+        Report report = runPmdTest(ValidTestCaseClass.class, rule);
+        assertReportViolations(report, 0);
+    }
+
+}

--- a/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRuleTest.java
+++ b/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseClassNamingRuleTest.java
@@ -29,8 +29,10 @@ public class TestCaseClassNamingRuleTest extends AbstractPmdTestCase {
     public void testInvalidClass() {
         TestCaseClassNamingRule rule = new TestCaseClassNamingRule();
         rule.setProperty(rule.regexProperty, "ValidTestCaseClass");
+        rule.setProperty(rule.messageProperty, "Class name not OK");
         Report report = runPmdTest(InvalidTestCaseClass.class, rule);
         assertReportViolations(report, 1);
+        assertReportViolationMessageMatches(report, 0, "Class name not OK");
     }
 
     @Test

--- a/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseMethodNamingRuleTest.java
+++ b/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseMethodNamingRuleTest.java
@@ -19,24 +19,24 @@ import net.sourceforge.pmd.Report;
 
 import org.aludratest.codecheck.rule.pmd.AbstractPmdTestCase;
 import org.junit.Test;
-import org.test.testclasses.testcase.InvalidTestCaseClass;
+import org.test.testclasses.testcase.InvalidMethodNameTestCaseClass;
 import org.test.testclasses.testcase.ValidTestCaseClass;
 
 @SuppressWarnings("javadoc")
-public class TestCaseClassNamingRuleTest extends AbstractPmdTestCase {
+public class TestCaseMethodNamingRuleTest extends AbstractPmdTestCase {
 
     @Test
     public void testInvalidClass() {
-        TestCaseClassNamingRule rule = new TestCaseClassNamingRule();
-        rule.setProperty(rule.regexProperty, "ValidTestCaseClass");
-        Report report = runPmdTest(InvalidTestCaseClass.class, rule);
+        TestCaseMethodNamingRule rule = new TestCaseMethodNamingRule();
+        Report report = runPmdTest(InvalidMethodNameTestCaseClass.class, rule);
         assertReportViolations(report, 1);
+        assertReportViolationMethod(report, 0, "test_illegal_name");
     }
 
     @Test
     public void testValidClass() {
-        TestCaseClassNamingRule rule = new TestCaseClassNamingRule();
-        rule.setProperty(rule.regexProperty, "ValidTestCaseClass");
+        TestCaseMethodNamingRule rule = new TestCaseMethodNamingRule();
+        rule.setProperty(rule.regexProperty, "test");
         Report report = runPmdTest(ValidTestCaseClass.class, rule);
         assertReportViolations(report, 0);
     }

--- a/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseMethodNamingRuleTest.java
+++ b/src/test/java/org/aludratest/codecheck/rule/pmd/testcase/TestCaseMethodNamingRuleTest.java
@@ -28,9 +28,11 @@ public class TestCaseMethodNamingRuleTest extends AbstractPmdTestCase {
     @Test
     public void testInvalidClass() {
         TestCaseMethodNamingRule rule = new TestCaseMethodNamingRule();
+        rule.setProperty(rule.messageProperty, "Method name not OK");
         Report report = runPmdTest(InvalidMethodNameTestCaseClass.class, rule);
         assertReportViolations(report, 1);
         assertReportViolationMethod(report, 0, "test_illegal_name");
+        assertReportViolationMessageMatches(report, 0, "Method name not OK");
     }
 
     @Test

--- a/src/test/java/org/test/testclasses/testcase/InvalidMethodNameTestCaseClass.java
+++ b/src/test/java/org/test/testclasses/testcase/InvalidMethodNameTestCaseClass.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.test.testclasses.testcase;
+
+import org.aludratest.testcase.AludraTestCase;
+import org.aludratest.testcase.Test;
+
+@SuppressWarnings("javadoc")
+public class InvalidMethodNameTestCaseClass extends AludraTestCase {
+
+    @Test
+    public void test_illegal_name() {
+    }
+
+    public void some_non_test_method() {
+    }
+
+}


### PR DESCRIPTION
Added a rule for test method names, configurable by the regular expression to apply and by the message to use for reporting violations.