### PR TITLE
EDI support: local ref files & FileChooser

### DIFF
--- a/src/main/java/org/aludratest/service/edifactfile/EdifactFileInteraction.java
+++ b/src/main/java/org/aludratest/service/edifactfile/EdifactFileInteraction.java
@@ -15,7 +15,9 @@
  */
 package org.aludratest.service.edifactfile;
 
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.util.Map;
 
 import org.aludratest.service.AttachParameter;
@@ -28,78 +30,86 @@ import org.aludratest.service.TechnicalLocator;
 import org.databene.edifatto.EdiFormatSymbols;
 import org.databene.edifatto.model.Interchange;
 
-/** 
+/**
  * Parses and saves EDIFACT and X12 documents from and to streams.
  * @author Volker Bergmann
  */
 public interface EdifactFileInteraction extends Interaction {
-    
-    /** Polls the file system until a file at the given path is found 
-     *  or a timeout occurs. 
-     *  @param elementType 
-     *  @param elementName 
+
+    /** Polls the file system until a file at the given path is found
+     *  or a timeout occurs.
+     *  @param elementType
+     *  @param elementName
      *  @param filePath */
     void waitUntilExists(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
+            @ElementType String elementType,
+            @ElementName String elementName,
             @TechnicalLocator String filePath);
-    
+
     /** Polls the file system until no file is found at the given path.
-     *  @param elementType 
-     *  @param elementName 
+     *  @param elementType
+     *  @param elementName
      *  @param filePath */
     void waitUntilNotExists(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
+            @ElementType String elementType,
+            @ElementName String elementName,
             @TechnicalLocator String filePath);
-    
+
     /** Deletes a file
-     *  @param elementType 
-     *  @param elementName 
+     *  @param elementType
+     *  @param elementName
      *  @param filePath the path of the file to delete */
     void delete(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
+            @ElementType String elementType,
+            @ElementName String elementName,
             @TechnicalLocator String filePath);
-    
-    /** Writes an EDIFACT or X12 interchange to an {@link OutputStream}. 
-     *  @param elementType 
-     *  @param elementName 
-     *  @param interchange the interchange to persist 
+
+    /** Writes an EDIFACT or X12 interchange to an {@link OutputStream}.
+     *  @param elementType
+     *  @param elementName
+     *  @param interchange the interchange to persist
      *  @param filePath the path of the file to write
      *  @param overwrite flag that indicates whether a pre-existing file may be overwritten */
     void writeInterchange(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
-            @AttachParameter("Interchange") Interchange interchange, 
-            @TechnicalLocator String filePath, 
+            @ElementType String elementType,
+            @ElementName String elementName,
+            @AttachParameter("Interchange") Interchange interchange,
+            @TechnicalLocator String filePath,
             @TechnicalArgument boolean overwrite);
-    
+
     /** Creates an {@link Interchange} based on a template file and a variable tree
-     *  @param elementType 
-     *  @param elementName 
+     *  @param elementType
+     *  @param elementName
      *  @param templateUri the path of the template file
      *  @param symbols the symbols to use
      *  @param variables the variable tree
      *  @return a new Interchange containing the information from the variable tree */
     @AttachResult("Created Interchange")
     Interchange createInterchange(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
-            @TechnicalLocator String templateUri, 
-            @TechnicalArgument EdiFormatSymbols symbols, 
+            @ElementType String elementType,
+            @ElementName String elementName,
+            @TechnicalLocator String templateUri,
+            @TechnicalArgument EdiFormatSymbols symbols,
             @TechnicalArgument Map<String, Object> variables);
-    
+
     /** Reads an {@link Interchange} from a file system.
-     *  @param elementType 
-     *  @param elementName 
-     *  @param filePath the full path of the file to read
-     *  @return an {@link Interchange} data structure 
-     *  	that contains the EDI data mapped to a tree structure */
+     * @param elementType
+     * @param elementName
+     * @param filePath the full path of the file to read
+     * @return an {@link Interchange} data structure that contains the EDI data mapped to a tree structure */
     @AttachResult("Read Interchange")
     Interchange readInterchange(
-            @ElementType String elementType, 
-            @ElementName String elementName, 
+            @ElementType String elementType,
+            @ElementName String elementName,
             @TechnicalLocator String filePath);
-    
+
+    /** Reads an {@link Interchange} from a {@link Reader}.
+     * @param elementType
+     * @param elementName
+     * @param in an {@link InputStream} that provides the interchange's textual representation
+     * @return an {@link Interchange} data structure that contains the EDI data mapped to a tree structure */
+    @AttachResult("Read Interchange")
+    Interchange readInterchange(@ElementType String elementType, @ElementName String elementName,
+            @TechnicalArgument InputStream in);
+
 }

--- a/src/main/java/org/aludratest/service/edifactfile/edifatto/EdifattoFileAction.java
+++ b/src/main/java/org/aludratest/service/edifactfile/edifatto/EdifattoFileAction.java
@@ -16,6 +16,7 @@
 package org.aludratest.service.edifactfile.edifatto;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -112,8 +113,14 @@ public class EdifattoFileAction implements EdifactFileInteraction, EdifactFileVe
 
     @Override
     public Interchange readInterchange(String elementType, String elementName, String filePath) {
-        String content = fileService.perform().readTextFile(filePath);
-        ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes()); // ENHANCE which encoding to use?
+        byte[] bytes = fileService.perform().readBinaryFile(filePath);
+        Interchange interchange = contentHandler.readInterchange(new ByteArrayInputStream(bytes));
+        memorizeInterchanges(null, interchange, null);
+        return interchange;
+    }
+
+    @Override
+    public Interchange readInterchange(String elementType, String elementName, InputStream in) {
         Interchange interchange = contentHandler.readInterchange(in);
         memorizeInterchanges(null, interchange, null);
         return interchange;

--- a/src/main/java/org/aludratest/service/file/File.java
+++ b/src/main/java/org/aludratest/service/file/File.java
@@ -18,6 +18,7 @@ package org.aludratest.service.file;
 import org.aludratest.dict.ActionWordLibrary;
 import org.aludratest.exception.AutomationException;
 import org.aludratest.exception.TechnicalException;
+import org.aludratest.service.file.data.FileData;
 import org.aludratest.service.file.data.TargetFileData;
 import org.aludratest.util.DataUtil;
 import org.aludratest.util.data.StringData;
@@ -154,6 +155,19 @@ public class File implements ActionWordLibrary<File> {
      */
     public File waitUntilExists() {
         service.perform().waitUntilExists(elementName, filePath);
+        return this;
+    }
+
+    /** Waits until a child file exists or a timeout occurs.
+     * @param chooser the {@link FileChooser} that chooses the file from the directory
+     * @param resultFile returns a reference to the chosen file
+     * @return a reference to the File object itself */
+    public File waitUntilChildExists(FileChooser chooser, FileData resultFile) {
+        if (resultFile == null) {
+            throw new AutomationException("No resultFile data object provided");
+        }
+        String chosenPath = service.perform().waitUntilChildExists(filePath, chooser);
+        resultFile.setFile(new File(chosenPath, service));
         return this;
     }
 

--- a/src/main/java/org/aludratest/service/file/FileChooser.java
+++ b/src/main/java/org/aludratest/service/file/FileChooser.java
@@ -15,25 +15,13 @@
  */
 package org.aludratest.service.file;
 
-/**
- * Provides elementary file information which might serve as filter criteria.
- * @author Volker Bergmann
- */
-public interface FileInfo {
+import java.util.List;
 
-    /** @return the name of the file */
-    public String getName();
-
-    /** @return the path of the file relative to the root folder of the related {@link FileService} */
-    public String getPath();
-
-    /** @return true if the file is a directory, otherwise false */
-    public boolean isDirectory();
-
-    /** @return the size of the file */
-    public long getSize();
-
-    /** @return the time at which the file was modified the last time */
-    long getLastModifiedTime();
-
+/** Chooses a file from a list.
+ * @author Volker Bergmann */
+public interface FileChooser {
+    /** Chooses a file from a list
+     * @param fileInfos the candidates from which to choose
+     * @return the chosen file or null if none met the criteria */
+    FileInfo chooseFrom(List<FileInfo> fileInfos);
 }

--- a/src/main/java/org/aludratest/service/file/FileInteraction.java
+++ b/src/main/java/org/aludratest/service/file/FileInteraction.java
@@ -162,4 +162,12 @@ public interface FileInteraction extends Interaction {
      *  @throws AutomationException if the file was not found within the timeout */
     String waitForFirstMatch(@TechnicalLocator String parentPath, FileFilter filter);
 
+    /** Polls the given directory until the filter finds a match or a timeout is exceeded. Timeout and the maximum number of polls
+     * are retrieved from the {@link org.aludratest.service.file.impl.FileServiceConfiguration}.
+     * @param dirPath the path of the directory in which to search for the file
+     * @param selector a {@link FileChooser} object that decides which file is to be accepted
+     * @return the file path of the file that was accepted by the filter, or null if none was accepted
+     * @throws AutomationException if the file was not found within the timeout */
+    String waitUntilChildExists(String dirPath, FileChooser selector);
+
 }

--- a/src/main/java/org/aludratest/service/file/data/FileData.java
+++ b/src/main/java/org/aludratest/service/file/data/FileData.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.file.data;
+
+import org.aludratest.dict.Data;
+import org.aludratest.service.file.File;
+
+/** Data class that holds a {@link File} object.
+ * @author Volker Bergmann */
+public class FileData extends Data {
+
+    private File file;
+
+    /** Default constructor */
+    public FileData() {
+        this(null);
+    }
+
+    /** Full constructor
+     * @param file the file to set */
+    public FileData(File file) {
+        this.file = file;
+    }
+
+    /** Returns the file property
+     * @return the file property */
+    public File getFile() {
+        return file;
+    }
+
+    /** Sets the file property.
+     * @param file the file to set */
+    public void setFile(File file) {
+        this.file = file;
+    }
+
+}

--- a/src/main/java/org/aludratest/service/file/impl/FileInfoImpl.java
+++ b/src/main/java/org/aludratest/service/file/impl/FileInfoImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.file.impl;
+
+import org.aludratest.exception.TechnicalException;
+import org.aludratest.service.file.FileInfo;
+import org.aludratest.service.file.FileService;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+
+/** Commons-VFS-based implementation of the FileInfo interface.
+ * @author Volker Bergmann */
+public class FileInfoImpl implements FileInfo {
+
+    /** The commons-vfs {@link FileObject} which provides the real data. */
+    private FileObject file;
+
+    private String path;
+
+    /** Constructor
+     * @param file the underlying {@link FileObject}.
+     * @param path the relative path from the FileService's root */
+    public FileInfoImpl(FileObject file, String path) {
+        this.file = file;
+        this.path = path;
+    }
+
+    /** Provides the file name without path elements.
+     * @return the file name */
+    @Override
+    public String getName() {
+        return file.getName().getBaseName();
+    }
+
+    /** Provides the path relative from the {@link FileService}'s root directory.
+     * @return the file path */
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    /** Tells if the file is a directory.
+     * @return true if a directory is referred, otherwise false */
+    @Override
+    public boolean isDirectory() {
+        try {
+            return (file.getType() == FileType.FOLDER);
+        }
+        catch (FileSystemException e) {
+            throw new TechnicalException("Error checking file type", e);
+        }
+    }
+
+    /** Provides the size of the file.
+     * @return the size of the file */
+    @Override
+    public long getSize() {
+        try {
+            return file.getContent().getSize();
+        }
+        catch (FileSystemException e) {
+            throw new TechnicalException("Error retrieving file size", e);
+        }
+    }
+
+    /** Provides the time stamp of the last file modification.
+     * @return the time stamp of the last file modification */
+    @Override
+    public long getLastModifiedTime() {
+        try {
+            return file.getContent().getLastModifiedTime();
+        }
+        catch (FileSystemException e) {
+            throw new TechnicalException("Error retrieving lastModifiedTime", e);
+        }
+    }
+
+    /** Provides the file name. */
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+}

--- a/src/main/java/org/aludratest/service/file/util/RegexNameFileChooser.java
+++ b/src/main/java/org/aludratest/service/file/util/RegexNameFileChooser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.file.util;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.aludratest.service.file.FileChooser;
+import org.aludratest.service.file.FileInfo;
+
+/** Chooses the first file whose name matches a regular expression.
+ * @author Volker Bergmann */
+public class RegexNameFileChooser implements FileChooser {
+
+    private Pattern pattern;
+
+    /** @param regex the regular expression to use */
+    public RegexNameFileChooser(String regex) {
+        setRegex(regex);
+    }
+
+    private void setRegex(String regex) {
+        this.pattern = Pattern.compile(regex);
+    }
+
+    @Override
+    public FileInfo chooseFrom(List<FileInfo> fileInfos) {
+        for (FileInfo file : fileInfos) {
+            if (this.pattern.matcher(file.getName()).matches()) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/test/java/org/aludratest/service/edifactfile/EdifactFileServiceIntegrationTest.java
+++ b/src/test/java/org/aludratest/service/edifactfile/EdifactFileServiceIntegrationTest.java
@@ -49,7 +49,7 @@ public class EdifactFileServiceIntegrationTest extends AbstractAludraServiceTest
     public void testVerify_identical() throws Exception {
         EdifactFileVerifier verifier = new EdifactFileVerifier("IFTDGN_1.edi", service) {
         };
-        verifier.verifyWith(new StringData("IFTDGN_1.edi"));
+        verifier.verifyWith(new StringData("target/test-classes/ediTest/IFTDGN_1.edi"));
         assertEquals(TestStatus.PASSED, getLoggedStatus());
     }
 
@@ -57,7 +57,7 @@ public class EdifactFileServiceIntegrationTest extends AbstractAludraServiceTest
     public void testVerify_different_negative() throws Exception {
         EdifactFileVerifier verifier = new EdifactFileVerifier("IFTDGN_1.edi", service) {
         };
-        verifier.verifyWith(new StringData("IFTDGN_2.edi"));
+        verifier.verifyWith(new StringData("target/test-classes/ediTest/IFTDGN_2.edi"));
         assertEquals(TestStatus.FAILED, getLoggedStatus());
     }
 

--- a/src/test/java/org/aludratest/service/file/FtpFileServiceTest.java
+++ b/src/test/java/org/aludratest/service/file/FtpFileServiceTest.java
@@ -96,7 +96,7 @@ public class FtpFileServiceTest extends AbstractAludraServiceTest {
                 fileCount++;
             }
         }
-        assertEquals(2, dirCount);
+        assertEquals(3, dirCount);
         assertEquals(1, fileCount);
     }
 

--- a/src/test/resources/fileServiceTest/testWaitUntilChildExists/preexisting.txt
+++ b/src/test/resources/fileServiceTest/testWaitUntilChildExists/preexisting.txt
@@ -1,0 +1,1 @@
+I preexisted


### PR DESCRIPTION
EDI support: Reading reference files from the local file system, introduced FileCooser

Usage: 
        File dir = new File("export", service);
        FileData result = new FileData();
        FileChooser chooser = new RegexNameFileChooser("preexisting.txt"); // use your own chooser
        dir.waitUntilChildExists(chooser, result);
        File chosenFile = result.getFile();
