### PR TITLE
Support multiple values per @TestAttribute annotation name

### DIFF
--- a/src/main/java/org/aludratest/scheduler/impl/RunnerTreeBuilderImpl.java
+++ b/src/main/java/org/aludratest/scheduler/impl/RunnerTreeBuilderImpl.java
@@ -497,7 +497,8 @@ public class RunnerTreeBuilderImpl implements RunnerTreeBuilder {
                 List<String> categories = new ArrayList<String>();
                 StringBuilder prefix = new StringBuilder();
                 for (String cat : categoryOrder) {
-                    String catVal = TestAttributeUtil.getTestAttributes(clazz).get(cat);
+                    List<String> catVals = TestAttributeUtil.getTestAttributes(clazz).get(cat);
+                    String catVal = catVals == null || catVals.isEmpty() ? null : catVals.get(0);
                     if (catVal == null) {
                         catVal = cat + " unknown";
                     }

--- a/src/main/java/org/aludratest/scheduler/util/AttributeBasedTestClassFilter.java
+++ b/src/main/java/org/aludratest/scheduler/util/AttributeBasedTestClassFilter.java
@@ -22,7 +22,17 @@ import java.util.Map;
 
 import org.aludratest.scheduler.TestClassFilter;
 import org.aludratest.testcase.AludraTestCase;
+import org.aludratest.testcase.TestAttribute;
 
+/** Filter for test classes based on their {@link TestAttribute} annotation(s) and according values. For a given name of a test
+ * attribute, one or more valid values can be specified. A value of <code>[]</code> specifies that a test case matches where this
+ * test attribute is not set at all. <br>
+ * If the test case has multiple {@link TestAttribute} annotations with the same name, the test case matches as soon as one of the
+ * associated values are contained in the list of valid values. <br>
+ * If the <code>invert</code> flag is set, the calculated match flag (as described above) is inverted before being returned by
+ * {@link #matches(Class)}.
+ *
+ * @author falbrech */
 public final class AttributeBasedTestClassFilter implements TestClassFilter {
 
     private String attributeName;
@@ -31,6 +41,11 @@ public final class AttributeBasedTestClassFilter implements TestClassFilter {
 
     private boolean invert;
 
+    /** Constructs a new attribute based test class filter.
+     *
+     * @param attributeName Name of the TestAttribute to match on.
+     * @param values List of accepted values for the TestAttribute.
+     * @param invert If <code>true</code>, the match result is inverted before being returned. */
     public AttributeBasedTestClassFilter(String attributeName, List<String> values, boolean invert) {
         this.attributeName = attributeName;
         this.values = Collections.unmodifiableList(new ArrayList<String>(values));
@@ -51,7 +66,7 @@ public final class AttributeBasedTestClassFilter implements TestClassFilter {
 
     @Override
     public boolean matches(Class<? extends AludraTestCase> testClass) {
-        Map<String, String> attributes = TestAttributeUtil.getTestAttributes(testClass);
+        Map<String, List<String>> attributes = TestAttributeUtil.getTestAttributes(testClass);
 
         boolean matchValue = false;
 
@@ -59,7 +74,10 @@ public final class AttributeBasedTestClassFilter implements TestClassFilter {
             matchValue = values.contains("[]");
         }
         else {
-            matchValue = values.contains(attributes.get(attributeName));
+            // one of the attributes set must be contained in values
+            for (String attrValue : attributes.get(attributeName)) {
+                matchValue |= values.contains(attrValue);
+            }
         }
 
         return invert ? !matchValue : matchValue;

--- a/src/main/java/org/aludratest/scheduler/util/TestAttributeUtil.java
+++ b/src/main/java/org/aludratest/scheduler/util/TestAttributeUtil.java
@@ -15,7 +15,10 @@
  */
 package org.aludratest.scheduler.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.aludratest.testcase.AludraTestCase;
@@ -23,7 +26,7 @@ import org.aludratest.testcase.TestAttribute;
 import org.aludratest.testcase.TestAttributes;
 
 /** Helper class for dealing with {@link TestAttribute} annotations.
- * 
+ *
  * @author falbrech */
 public final class TestAttributeUtil {
 
@@ -31,22 +34,26 @@ public final class TestAttributeUtil {
     }
 
     /** Determines all test attributes of the given test case class.
-     * 
+     *
      * @param testClass Test case class.
-     * 
+     *
      * @return All test attributes of the given test case class. */
-    public static Map<String, String> getTestAttributes(Class<? extends AludraTestCase> testClass) {
+    public static Map<String, List<String>> getTestAttributes(Class<? extends AludraTestCase> testClass) {
         TestAttribute attr = testClass.getAnnotation(TestAttribute.class);
         TestAttributes attrs = testClass.getAnnotation(TestAttributes.class);
 
-        Map<String, String> result = new HashMap<String, String>();
+        Map<String, List<String>> result = new HashMap<String, List<String>>();
 
         if (attr != null) {
-            result.put(attr.name(), attr.value());
+            result.put(attr.name(), Collections.singletonList(attr.value()));
         }
         if (attrs != null) {
             for (TestAttribute a : attrs.value()) {
-                result.put(a.name(), a.value());
+                List<String> ls = result.get(a.name());
+                if (ls == null) {
+                    result.put(a.name(), ls = new ArrayList<String>());
+                }
+                ls.add(a.value());
             }
         }
 

--- a/src/test/java/org/aludratest/scheduler/impl/RunnerTreeBuilderImplTest.java
+++ b/src/test/java/org/aludratest/scheduler/impl/RunnerTreeBuilderImplTest.java
@@ -24,7 +24,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.aludratest.PreconditionFailedException;
 import org.aludratest.invoker.TestInvoker;
@@ -37,6 +39,7 @@ import org.aludratest.scheduler.node.RunnerLeaf;
 import org.aludratest.scheduler.node.RunnerNode;
 import org.aludratest.scheduler.test.annot.AnnotatedTestClass1;
 import org.aludratest.scheduler.test.annot.AnnotatedTestClass2;
+import org.aludratest.scheduler.test.annot.AnnotatedTestClass3;
 import org.aludratest.scheduler.util.FilterParser;
 import org.aludratest.service.AbstractAludraIntegrationTest;
 import org.aludratest.suite.DuplicateChildSuite;
@@ -238,30 +241,27 @@ public class RunnerTreeBuilderImplTest extends AbstractAludraIntegrationTest {
         assertEquals("InWork", tree.getRoot().getChildren().get(0).getName());
 
         RunnerGroup group = (RunnerGroup) tree.getRoot().getChildren().get(0);
-        assertEquals(2, group.getChildren().size());
+        assertEquals(3, group.getChildren().size());
         List<String> names = new ArrayList<String>();
         names.add(group.getChildren().get(0).getName());
         names.add(group.getChildren().get(1).getName());
+        names.add(group.getChildren().get(2).getName());
         assertTrue(names.contains("InWork.falbrech"));
         assertTrue(names.contains("InWork.jdoe"));
+        assertTrue(names.contains("InWork.secondauthor"));
 
         // and the actual classes
-        RunnerGroup classGroup = (RunnerGroup) group.getChildren().get(0);
-        assertEquals(1, classGroup.getChildren().size());
-        if ("InWork.falbrech".equals(classGroup.getName())) {
-            assertEquals(AnnotatedTestClass1.class.getName(), classGroup.getChildren().get(0).getName());
+        Map<String, String> classNames = new HashMap<String, String>();
+
+        for (RunnerNode node : group.getChildren()) {
+            RunnerGroup classGroup = (RunnerGroup) node;
+            assertEquals(1, classGroup.getChildren().size());
+            classNames.put(classGroup.getName(), classGroup.getChildren().get(0).getName());
         }
-        else {
-            assertEquals(AnnotatedTestClass2.class.getName(), classGroup.getChildren().get(0).getName());
-        }
-        classGroup = (RunnerGroup) group.getChildren().get(1);
-        assertEquals(1, classGroup.getChildren().size());
-        if ("InWork.falbrech".equals(classGroup.getName())) {
-            assertEquals(AnnotatedTestClass1.class.getName(), classGroup.getChildren().get(0).getName());
-        }
-        else {
-            assertEquals(AnnotatedTestClass2.class.getName(), classGroup.getChildren().get(0).getName());
-        }
+
+        assertEquals(AnnotatedTestClass1.class.getName(), classNames.get("InWork.falbrech"));
+        assertEquals(AnnotatedTestClass2.class.getName(), classNames.get("InWork.jdoe"));
+        assertEquals(AnnotatedTestClass3.class.getName(), classNames.get("InWork.secondauthor"));
     }
 
     @Test
@@ -276,7 +276,7 @@ public class RunnerTreeBuilderImplTest extends AbstractAludraIntegrationTest {
         RunnerTree tree = builder.buildRunnerTree(exec);
         RunnerGroup group = tree.getRoot();
         assertEquals("All Tests", group.getName());
-        assertEquals(2, group.getChildren().size());
+        assertEquals(3, group.getChildren().size());
     }
 
     @Test

--- a/src/test/java/org/aludratest/scheduler/test/annot/AnnotatedTestClass3.java
+++ b/src/test/java/org/aludratest/scheduler/test/annot/AnnotatedTestClass3.java
@@ -20,10 +20,10 @@ import org.aludratest.testcase.Test;
 import org.aludratest.testcase.TestAttribute;
 import org.aludratest.testcase.TestAttributes;
 
-@TestAttributes({ @TestAttribute(name = "author", value = "falbrech"), @TestAttribute(name = "author", value = "secondauthor"),
-        @TestAttribute(name = "state", value = "InWork"),
+@TestAttributes({ @TestAttribute(name = "author", value = "secondauthor"), @TestAttribute(name = "author", value = "falbrech"),
+    @TestAttribute(name = "state", value = "InWork"),
     @TestAttribute(name = "testName", value = "RunnerTreeBuilderImplTest") })
-public class AnnotatedTestClass1 extends AludraTestCase {
+public class AnnotatedTestClass3 extends AludraTestCase {
 
     @Test
     public void testSth() {


### PR DESCRIPTION
For categorization (runner tree building), the first value for the
category name (e.g. test author) will be used.

Filtering logic is described in AttributeBasedTestClassFilter.