### PR TITLE
Add timetravel(date) Javascript function

### DIFF
--- a/src/main/java/org/aludratest/testcase/data/impl/xml/DefaultScriptLibrary.java
+++ b/src/main/java/org/aludratest/testcase/data/impl/xml/DefaultScriptLibrary.java
@@ -19,20 +19,25 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import org.aludratest.config.AludraTestConfig;
 import org.aludratest.exception.TechnicalException;
 import org.apache.commons.io.IOUtils;
 import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 
 /** Default JavaScript library shipped with AludraTest.
- * 
+ *
  * @author falbrech */
 @Component(role = ScriptLibrary.class, hint = "default")
 public final class DefaultScriptLibrary implements ScriptLibrary {
 
     private static final String JS_ADD_DAYS_TO_NOW = "function addDaysToNow(days_add) { return new Date(new Date().getTime() + days_add * 24 * 60 * 60 * 1000); }";
     private static final String JS_ADD_HOURS_TO_NOW = "function addHoursToNow(hours_add) { return new Date(new Date().getTime() + hours_add * 60 * 60 * 1000); }";
+
+    @Requirement
+    private AludraTestConfig aludraConfig;
 
     @Override
     public void addFunctionsToContext(Context context, Scriptable scope) {
@@ -42,6 +47,19 @@ public final class DefaultScriptLibrary implements ScriptLibrary {
 
         // complex Date format addition
         loadScript(context, scope, "date-format.js");
+
+        // timetravel() function
+        long timetravelDiff = aludraConfig.getScriptSecondsOffset() * 1000;
+        if (timetravelDiff == 0) {
+            context.evaluateString(scope, "function timetravel(date) { return date; }", "jsTimetravel", 1, null);
+        }
+        else {
+            context.evaluateString(scope,
+                    "function timetravel(date) { return new Date(date.getTime() + (" + timetravelDiff + ")); }", "jsTimetravel",
+                    1,
+                    null);
+        }
+
     }
 
     private void loadScript(Context context, Scriptable scope, String jsResourceName) {

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -125,6 +125,13 @@
       <implementation>org.aludratest.testcase.data.impl.xml.DefaultScriptLibrary</implementation>
       <description></description>
       <isolated-realm>false</isolated-realm>
+      <requirements>
+        <requirement>
+          <role>org.aludratest.config.AludraTestConfig</role>
+          <role-hint></role-hint>
+          <field-name>aludraConfig</field-name>
+        </requirement>
+      </requirements>
     </component>
     <component>
       <role>org.aludratest.service.ServiceWrapper</role>

--- a/src/test/java/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest.java
+++ b/src/test/java/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest.java
@@ -53,7 +53,10 @@ public class XmlBasedTestDataProviderTest {
         }
 
         Map<String, ScriptLibrary> libs = new HashMap<String, ScriptLibrary>();
-        libs.put("default", new DefaultScriptLibrary());
+
+        DefaultScriptLibrary lib = new DefaultScriptLibrary();
+        ReflectionUtils.setVariableValueInObject(lib, "aludraConfig", config);
+        libs.put("default", lib);
 
         ReflectionUtils.setVariableValueInObject(provider, "aludraConfig", config);
         ReflectionUtils.setVariableValueInObject(provider, "scriptLibraries", libs);
@@ -169,8 +172,11 @@ public class XmlBasedTestDataProviderTest {
         config.setScriptSecondsOffset(Integer.valueOf(-86400));
         XmlBasedTestDataProvider provider = createProvider(config);
         List<TestCaseData> testData = provider
-                .getTestDataSets(XmlBasedTestDataProviderTest.class.getDeclaredMethod("testMethodTimetravel", StringData.class));
+                .getTestDataSets(XmlBasedTestDataProviderTest.class.getDeclaredMethod("testMethodTimetravel", StringData.class,
+                        StringData.class));
         assertEquals("2015-03-07 23:58", ((StringData) testData.get(0).getData()[0]).getValue());
+        // uses timetravel() JavaScript method
+        assertEquals("Test 2016-08-27", ((StringData) testData.get(0).getData()[1]).getValue());
     }
 
     @Test
@@ -245,7 +251,8 @@ public class XmlBasedTestDataProviderTest {
         }
     }
 
-    public void testMethodTimetravel(@Source(uri = "timetravel.testdata.xml", segment = "stringObject") StringData object) {
+    public void testMethodTimetravel(@Source(uri = "timetravel.testdata.xml", segment = "stringObject") StringData object,
+            @Source(uri = "timetravel.testdata.xml", segment = "secondObject") StringData secondObject) {
         if (object == null) {
             // do nothing
         }

--- a/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
+++ b/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
@@ -38,16 +38,5 @@
     		</segment>
     	</segments>
     </configuration>
-    <configuration name="config2">
-    	<segments>
-    		<segment name="stringObject">
-    			<fieldValues>
-    				<fieldValue name="value">
-    					<value></value>
-    				</fieldValue>
-    			</fieldValues>
-    		</segment>
-    	</segments>
-    </configuration>
     </configurations>
 </testdata>

--- a/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
+++ b/src/test/resources/org/aludratest/testcase/data/xml/XmlBasedTestDataProviderTest/timetravel.testdata.xml
@@ -11,6 +11,11 @@
         	<field name="value" fieldType="DATE" formatterPattern="yyyy-MM-dd HH:mm"/>
         </fields>
         </segment>
+        <segment name="secondObject" dataClassName="org.aludratest.util.data.StringData">
+        	<fields>
+        		<field name="value" />
+        	</fields>
+        </segment>
         </segments>
     </metadata>
 
@@ -21,6 +26,24 @@
     			<fieldValues>
     				<fieldValue name="value" script="true">
     					<value>new Date(&quot;8 Mar 2015 23:58:00&quot;)</value>
+    				</fieldValue>
+    			</fieldValues>
+    		</segment>
+    		<segment name="secondObject">
+    			<fieldValues>
+    				<fieldValue name="value" script="true">
+    					<value>&quot;Test &quot; + timetravel(new Date(1472342400000)).format(&quot;yyyy-mm-dd&quot;)</value>
+    				</fieldValue>
+    			</fieldValues>
+    		</segment>
+    	</segments>
+    </configuration>
+    <configuration name="config2">
+    	<segments>
+    		<segment name="stringObject">
+    			<fieldValues>
+    				<fieldValue name="value">
+    					<value></value>
     				</fieldValue>
     			</fieldValues>
     		</segment>


### PR DESCRIPTION
This enables timetravel in concatenated function expressions not
returning Date objects (but e.g. strings).