### PR TITLE
Add convenience 1-param String assertion methods to components

### DIFF
--- a/src/main/java/org/aludratest/service/gui/component/Element.java
+++ b/src/main/java/org/aludratest/service/gui/component/Element.java
@@ -51,6 +51,14 @@ public interface Element<E extends Element<E>> extends GUIComponent {
      * @see #assertNotPresent() */
     public void assertPresent(boolean expected);
 
+    /** Asserts that the element is present or is not present, depending on the passed parameter.
+     *
+     * @param expected if <code>"true"</code> (any case), assert that element is present, otherwise, assert that element is not
+     *            present.
+     * @see #assertPresent()
+     * @see #assertNotPresent() */
+    public void assertPresent(String expected);
+
     /** Asserts that the element is visible */
     public void assertVisible();
 
@@ -63,6 +71,13 @@ public interface Element<E extends Element<E>> extends GUIComponent {
      * @see #assertNotVisible() */
     public void assertVisible(boolean expected);
 
+    /** Asserts that the element is visible or is not visible, depending on the passed parameter.
+     * @param expected if <code>"true"</code> (any case), assert that element is visible, otherwise, assert that element is not
+     *            visible.
+     * @see #assertVisible()
+     * @see #assertNotVisible() */
+    public void assertVisible(String expected);
+
     /** Asserts that this element is enabled, i.e. does not have an active "disabled" state. */
     public void assertEnabled();
 
@@ -74,6 +89,13 @@ public interface Element<E extends Element<E>> extends GUIComponent {
      * @see #assertEnabled()
      * @see #assertNotEnabled() */
     public void assertEnabled(boolean expected);
+
+    /** Asserts that the element is enabled or is not enabled, depending on the passed parameter.
+     * @param expected if <code>"true"</code> (any case), assert that element is enabled, otherwise, assert that element is not
+     *            enabled.
+     * @see #assertEnabled()
+     * @see #assertNotEnabled() */
+    public void assertEnabled(String expected);
 
     /** Asserts that the element has the focus. */
     public void assertFocus();

--- a/src/main/java/org/aludratest/service/gui/component/impl/AbstractElement.java
+++ b/src/main/java/org/aludratest/service/gui/component/impl/AbstractElement.java
@@ -19,6 +19,7 @@ import org.aludratest.exception.PerformanceFailure;
 import org.aludratest.service.SystemConnector;
 import org.aludratest.service.gui.component.Element;
 import org.aludratest.service.locator.element.GUIElementLocator;
+import org.aludratest.util.DataUtil;
 import org.aludratest.util.data.helper.DataMarkerCheck;
 
 /** Parent class for GUI Elements e.g. Button.
@@ -76,6 +77,11 @@ public abstract class AbstractElement<E extends Element<E>> extends AbstractGUIC
     }
 
     @Override
+    public void assertPresent(String expected) {
+        assertPresent(DataUtil.parseBoolean(expected));
+    }
+
+    @Override
     public void assertVisible() {
         verify().assertVisible(elementType, elementName, getLocator());
     }
@@ -93,6 +99,11 @@ public abstract class AbstractElement<E extends Element<E>> extends AbstractGUIC
         else {
             assertNotVisible();
         }
+    }
+
+    @Override
+    public void assertVisible(String expected) {
+        assertVisible(DataUtil.parseBoolean(expected));
     }
 
     @Override
@@ -114,6 +125,11 @@ public abstract class AbstractElement<E extends Element<E>> extends AbstractGUIC
         else {
             assertNotEnabled();
         }
+    }
+
+    @Override
+    public void assertEnabled(String expected) {
+        assertEnabled(DataUtil.parseBoolean(expected));
     }
 
     @Override


### PR DESCRIPTION
This adds methods like assertVisible(String) to the UI Element 
interface and its standard base implementation. These convenience
methods call assertXyz() if their parameter is parsed to true, and
assertNotXyZ() otherwise. This allows for better control of
assertions via test data.